### PR TITLE
Implement Hedg-Bot web control panel

### DIFF
--- a/hedgbot/__init__.py
+++ b/hedgbot/__init__.py
@@ -1,0 +1,8 @@
+"""Hedge-Bot package."""
+
+__all__ = [
+    "config",
+    "models",
+    "bot",
+    "manager",
+]

--- a/hedgbot/app/static/app.js
+++ b/hedgbot/app/static/app.js
@@ -1,0 +1,344 @@
+const API = {
+  async request(url, options = {}) {
+    const response = await fetch(url, {
+      headers: { "Content-Type": "application/json", ...(options.headers || {}) },
+      ...options,
+    });
+    if (!response.ok) {
+      const detail = await response.json().catch(() => ({}));
+      const message = detail.detail || response.statusText || "Ошибка запроса";
+      throw new Error(message);
+    }
+    if (response.status === 204) {
+      return null;
+    }
+    return response.json();
+  },
+
+  listInstruments() {
+    return this.request("/api/instruments");
+  },
+
+  updateConfig(symbol, payload) {
+    return this.request(`/api/instruments/${symbol}/config`, {
+      method: "POST",
+      body: JSON.stringify(payload),
+    });
+  },
+
+  start(symbol) {
+    return this.request(`/api/instruments/${symbol}/start`, { method: "POST" });
+  },
+
+  stop(symbol) {
+    return this.request(`/api/instruments/${symbol}/stop`, { method: "POST" });
+  },
+
+  close(symbol) {
+    return this.request(`/api/instruments/${symbol}/close`, { method: "POST" });
+  },
+
+  startAll() {
+    return this.request(`/api/instruments/start_all`, { method: "POST" });
+  },
+
+  stopAll() {
+    return this.request(`/api/instruments/stop_all`, { method: "POST" });
+  },
+
+  refreshInstrument(symbol) {
+    return this.request(`/api/instruments/${symbol}`);
+  },
+};
+
+function setupTabs(card) {
+  const buttons = card.querySelectorAll(".tab-button");
+  buttons.forEach((button) => {
+    button.addEventListener("click", () => {
+      buttons.forEach((b) => b.classList.remove("active"));
+      button.classList.add("active");
+      const target = button.dataset.target;
+      card
+        .querySelectorAll(".tab-content")
+        .forEach((section) => section.classList.remove("active"));
+      card
+        .querySelector(`.tab-content[data-tab="${target}"]`)
+        .classList.add("active");
+    });
+  });
+}
+
+function createStopLossRow(offset = "", volume = "") {
+  const row = document.createElement("div");
+  row.className = "stop-loss-row";
+  row.innerHTML = `
+    <label>
+      Отступ (%):
+      <input type="number" step="0.01" name="sl-offset" value="${offset}" required />
+    </label>
+    <label>
+      Объём (%):
+      <input type="number" step="0.01" name="sl-volume" value="${volume}" required />
+    </label>
+    <button type="button" class="remove-stop">×</button>
+  `;
+  row.querySelector(".remove-stop").addEventListener("click", () => {
+    row.remove();
+  });
+  return row;
+}
+
+function collectStopLosses(container) {
+  return Array.from(container.querySelectorAll(".stop-loss-row")).map((row) => ({
+    offset_percent: parseFloat(row.querySelector('input[name="sl-offset"]').value),
+    volume_percent: parseFloat(row.querySelector('input[name="sl-volume"]').value),
+  }));
+}
+
+function renderStopLosses(container, stopLosses) {
+  container.innerHTML = "";
+  stopLosses.forEach((sl) => {
+    container.appendChild(createStopLossRow(sl.offset_percent, sl.volume_percent));
+  });
+}
+
+function collectConfig(card) {
+  const form = card.querySelector(".config-form");
+  const symbol = card.dataset.symbol;
+  const entryAmount = parseFloat(form.querySelector('input[name="entry_amount"]').value);
+  const tpRows = Array.from(form.querySelectorAll(".tp-row"));
+  const takeProfits = tpRows.map((row) => ({
+    label: row.dataset.label,
+    offset_percent: parseFloat(row.querySelector('input[name="tp-offset"]').value),
+    volume_percent: parseFloat(row.querySelector('input[name="tp-volume"]').value),
+  }));
+
+  const stopLossContainer = form.querySelector(".stop-loss-list");
+  const stopLosses = collectStopLosses(stopLossContainer);
+
+  const dcaEnabled = form.querySelector('input[name="dca-enabled"]').checked;
+  const dcaOffsetValue = form.querySelector('input[name="dca-offset"]').value.trim();
+  const dcaQuantityValue = form.querySelector('input[name="dca-quantity"]').value.trim();
+
+  if (dcaEnabled && (!dcaOffsetValue || !dcaQuantityValue)) {
+    throw new Error("Для включенной доливки необходимо указать отступ и объём");
+  }
+
+  const tp1Dca = {
+    enabled: dcaEnabled,
+    offset_percent: dcaOffsetValue ? parseFloat(dcaOffsetValue) : null,
+    quantity: dcaQuantityValue ? parseFloat(dcaQuantityValue) : null,
+  };
+
+  return {
+    symbol,
+    entry_amount: entryAmount,
+    take_profits: takeProfits,
+    stop_losses: stopLosses,
+    tp1_dca: tp1Dca,
+  };
+}
+
+function renderInstrument(card, data) {
+  card
+    .querySelector('input[name="entry_amount"]')
+    .value = data.config.entry_amount;
+  const tpRows = card.querySelectorAll(".tp-row");
+  tpRows.forEach((row, index) => {
+    const tp = data.config.take_profits[index];
+    row.querySelector('input[name="tp-offset"]').value = tp.offset_percent;
+    row.querySelector('input[name="tp-volume"]').value = tp.volume_percent;
+  });
+
+  const stopLossContainer = card.querySelector(".stop-loss-list");
+  renderStopLosses(stopLossContainer, data.config.stop_losses);
+
+  const dcaEnabled = card.querySelector('input[name="dca-enabled"]');
+  dcaEnabled.checked = data.config.tp1_dca.enabled;
+  card.querySelector('input[name="dca-offset"]').value =
+    data.config.tp1_dca.offset_percent ?? "";
+  card.querySelector('input[name="dca-quantity"]').value =
+    data.config.tp1_dca.quantity ?? "";
+
+  const statusIndicator = card.querySelector(".status-indicator");
+  statusIndicator.dataset.running = data.is_running ? "true" : "false";
+  statusIndicator.textContent = data.is_running ? "Работает" : "Остановлен";
+  card.querySelector(".status-text").textContent = data.is_running
+    ? "Работает"
+    : "Остановлен";
+
+  const longPosition = Number(data.positions.LONG ?? 0);
+  const shortPosition = Number(data.positions.SHORT ?? 0);
+  card.querySelector('[data-position="LONG"]').textContent = longPosition.toFixed(2);
+  card.querySelector('[data-position="SHORT"]').textContent = shortPosition.toFixed(2);
+
+  const ordersTable = card.querySelector(".open-orders tbody");
+  if (ordersTable) {
+    ordersTable.innerHTML = data.open_orders
+      .map(
+        (order) => `
+        <tr>
+          <td>${order.id}</td>
+          <td>${order.type}</td>
+          <td>${order.side}</td>
+          <td>${Number(order.quantity ?? 0).toFixed(2)}</td>
+          <td>${order.status}</td>
+        </tr>
+      `
+      )
+      .join("");
+  }
+
+  const dcaTable = card.querySelector(".dca-table tbody");
+  if (dcaTable) {
+    dcaTable.innerHTML = data.dca_orders
+      .map(
+        (order) => `
+        <tr>
+          <td>${order.id}</td>
+          <td>${order.side}</td>
+          <td>${Number(order.quantity ?? 0).toFixed(2)}</td>
+          <td>${order.status}</td>
+        </tr>
+      `
+      )
+      .join("");
+  }
+
+  const logList = card.querySelector(".log-list ul");
+  if (logList) {
+    logList.innerHTML = data.logs
+      .slice()
+      .reverse()
+      .map(
+        (entry) => `
+        <li>
+          <time>${new Date(entry.timestamp).toLocaleString()}</time>
+          <span class="level level-${entry.level.toLowerCase()}">${entry.level}</span>
+          <span class="message">${entry.message}</span>
+        </li>
+      `
+      )
+      .join("");
+  }
+}
+
+function setupConfigForm(card) {
+  const form = card.querySelector(".config-form");
+  const stopLossContainer = form.querySelector(".stop-loss-list");
+  const addStopButton = form.querySelector(".add-stop");
+
+  addStopButton.addEventListener("click", () => {
+    if (stopLossContainer.children.length >= 10) {
+      alert("Можно задать не более 10 стоп-лоссов");
+      return;
+    }
+    stopLossContainer.appendChild(createStopLossRow());
+  });
+
+  form.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    const symbol = card.dataset.symbol;
+    try {
+      const config = collectConfig(card);
+      const data = await API.updateConfig(symbol, config);
+      renderInstrument(card, data);
+      alert("Настройки обновлены");
+    } catch (error) {
+      alert(error.message);
+    }
+  });
+}
+
+function setupStatusActions(card) {
+  const symbol = card.dataset.symbol;
+  const startButton = card.querySelector(".status-actions .start");
+  const stopButton = card.querySelector(".status-actions .stop");
+  const closeButton = card.querySelector(".status-actions .close");
+
+  startButton.addEventListener("click", async () => {
+    try {
+      const data = await API.start(symbol);
+      renderInstrument(card, data);
+    } catch (error) {
+      alert(error.message);
+    }
+  });
+
+  stopButton.addEventListener("click", async () => {
+    try {
+      const data = await API.stop(symbol);
+      renderInstrument(card, data);
+    } catch (error) {
+      alert(error.message);
+    }
+  });
+
+  closeButton.addEventListener("click", async () => {
+    if (!confirm("Закрыть позицию и отменить ордера?")) {
+      return;
+    }
+    try {
+      const data = await API.close(symbol);
+      renderInstrument(card, data);
+    } catch (error) {
+      alert(error.message);
+    }
+  });
+}
+
+function setupLogRefresh(card) {
+  const refreshButton = card.querySelector(".log-list .refresh");
+  const symbol = card.dataset.symbol;
+  if (!refreshButton) return;
+  refreshButton.addEventListener("click", async () => {
+    try {
+      const data = await API.refreshInstrument(symbol);
+      renderInstrument(card, data);
+    } catch (error) {
+      alert(error.message);
+    }
+  });
+}
+
+function initGlobalControls() {
+  const startAll = document.getElementById("start-all");
+  const stopAll = document.getElementById("stop-all");
+
+  startAll.addEventListener("click", async () => {
+    try {
+      const state = await API.startAll();
+      updateAll(state);
+    } catch (error) {
+      alert(error.message);
+    }
+  });
+
+  stopAll.addEventListener("click", async () => {
+    try {
+      const state = await API.stopAll();
+      updateAll(state);
+    } catch (error) {
+      alert(error.message);
+    }
+  });
+}
+
+function updateAll(managerState) {
+  managerState.instruments.forEach((instrument) => {
+    const card = document.querySelector(`.instrument-card[data-symbol="${instrument.symbol}"]`);
+    if (card) {
+      renderInstrument(card, instrument);
+    }
+  });
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  document.querySelectorAll(".instrument-card").forEach((card) => {
+    setupTabs(card);
+    setupConfigForm(card);
+    setupStatusActions(card);
+    setupLogRefresh(card);
+  });
+  initGlobalControls();
+});

--- a/hedgbot/app/static/styles.css
+++ b/hedgbot/app/static/styles.css
@@ -1,0 +1,283 @@
+:root {
+  color-scheme: dark light;
+  font-family: "Segoe UI", Roboto, sans-serif;
+  background-color: #f7f9fc;
+  color: #1f2933;
+}
+
+body {
+  margin: 0;
+  background: linear-gradient(180deg, #0f172a 0%, #1e293b 60%, #f7f9fc 100%);
+  min-height: 100vh;
+}
+
+main {
+  padding: 1.5rem;
+}
+
+.app-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.5rem 1.5rem 0;
+  color: #f8fafc;
+}
+
+.app-header h1 {
+  margin: 0;
+  font-size: 1.75rem;
+}
+
+.global-controls button {
+  margin-left: 0.5rem;
+}
+
+.instruments {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+}
+
+.instrument-card {
+  background-color: rgba(255, 255, 255, 0.95);
+  border-radius: 16px;
+  padding: 1rem;
+  box-shadow: 0 12px 32px rgba(15, 23, 42, 0.3);
+  display: flex;
+  flex-direction: column;
+}
+
+.instrument-card header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.75rem;
+}
+
+.instrument-card h2 {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.status-indicator {
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  font-weight: 600;
+  color: #0f172a;
+  background-color: #cbd5f5;
+}
+
+.status-indicator[data-running="true"] {
+  background-color: #bbf7d0;
+  color: #14532d;
+}
+
+.status-indicator[data-running="false"] {
+  background-color: #fecaca;
+  color: #7f1d1d;
+}
+
+.tab-bar {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.tab-button {
+  flex: 1;
+  padding: 0.5rem 0.75rem;
+  border-radius: 999px;
+  border: none;
+  background-color: #e2e8f0;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.tab-button.active {
+  background-color: #3b82f6;
+  color: #fff;
+}
+
+.tab-content {
+  display: none;
+}
+
+.tab-content.active {
+  display: block;
+}
+
+.config-form .field-group,
+.config-form fieldset {
+  margin-bottom: 1rem;
+}
+
+.config-form fieldset {
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  padding: 0.75rem;
+}
+
+.config-form legend {
+  font-weight: 600;
+  padding: 0 0.25rem;
+}
+
+.tp-row,
+.stop-loss-row,
+.dca-fields {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.5rem;
+}
+
+.tp-row strong {
+  width: 40px;
+}
+
+.config-form input[type="number"] {
+  width: 110px;
+  padding: 0.35rem 0.5rem;
+  border-radius: 8px;
+  border: 1px solid #cbd5f5;
+  background-color: #f8fafc;
+}
+
+.add-stop,
+.remove-stop {
+  padding: 0.35rem 0.75rem;
+  border-radius: 8px;
+  border: none;
+  cursor: pointer;
+}
+
+.add-stop {
+  background-color: #e0f2fe;
+  color: #0f172a;
+}
+
+.remove-stop {
+  background-color: #fecaca;
+  color: #7f1d1d;
+}
+
+.checkbox {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.form-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+button.primary,
+button.secondary,
+button.danger {
+  padding: 0.5rem 1rem;
+  border-radius: 999px;
+  border: none;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+button.primary {
+  background-color: #2563eb;
+  color: #fff;
+}
+
+button.secondary {
+  background-color: #e2e8f0;
+  color: #0f172a;
+}
+
+button.danger {
+  background-color: #ef4444;
+  color: #fff;
+}
+
+.status-panel ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.status-panel li {
+  margin-bottom: 0.25rem;
+}
+
+.orders-list table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 1rem;
+}
+
+.orders-list th,
+.orders-list td {
+  border-bottom: 1px solid #e2e8f0;
+  text-align: left;
+  padding: 0.5rem;
+}
+
+.log-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.log-list ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  max-height: 240px;
+  overflow-y: auto;
+}
+
+.log-list li {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.35rem 0.25rem;
+  border-bottom: 1px dashed #cbd5f5;
+}
+
+.log-list time {
+  font-size: 0.75rem;
+  color: #475569;
+}
+
+.level {
+  font-size: 0.75rem;
+  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+  font-weight: 600;
+}
+
+.level-info {
+  background-color: #dbeafe;
+  color: #1e40af;
+}
+
+.level-warning {
+  background-color: #fef3c7;
+  color: #92400e;
+}
+
+.level-error {
+  background-color: #fee2e2;
+  color: #991b1b;
+}
+
+@media (max-width: 640px) {
+  .tp-row,
+  .stop-loss-row,
+  .dca-fields {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .config-form input[type="number"] {
+    width: 100%;
+  }
+}

--- a/hedgbot/app/templates/index.html
+++ b/hedgbot/app/templates/index.html
@@ -1,0 +1,183 @@
+<!DOCTYPE html>
+<html lang="ru">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Hedg-Bot панель управления</title>
+    <link rel="stylesheet" href="/static/styles.css" />
+  </head>
+  <body>
+    <header class="app-header">
+      <h1>Hedg-Bot — управление стратегиями</h1>
+      <div class="global-controls">
+        <button id="start-all" class="primary">Запустить все</button>
+        <button id="stop-all" class="secondary">Остановить все</button>
+      </div>
+    </header>
+
+    <main>
+      <section class="instruments">
+        {% for instrument in state.instruments %}
+        <article class="instrument-card" data-symbol="{{ instrument.symbol }}">
+          <header>
+            <h2>{{ instrument.symbol }}</h2>
+            <span class="status-indicator" data-running="{{ 'true' if instrument.is_running else 'false' }}">
+              {{ 'Работает' if instrument.is_running else 'Остановлен' }}
+            </span>
+          </header>
+
+          <nav class="tab-bar">
+            <button class="tab-button active" data-target="settings">Настройки</button>
+            <button class="tab-button" data-target="status">Статус / Запуск</button>
+            <button class="tab-button" data-target="orders">Ордеры</button>
+            <button class="tab-button" data-target="logs">Лог</button>
+          </nav>
+
+          <section class="tab-content settings active" data-tab="settings">
+            <form class="config-form">
+              <input type="hidden" name="symbol" value="{{ instrument.symbol }}" />
+              <div class="field-group">
+                <label>Объём входа (USDT)
+                  <input type="number" step="0.01" name="entry_amount" value="{{ instrument.config.entry_amount }}" required />
+                </label>
+              </div>
+
+              <fieldset>
+                <legend>Тейк-профиты</legend>
+                {% for tp in instrument.config.take_profits %}
+                <div class="tp-row" data-label="{{ tp.label }}">
+                  <strong>{{ tp.label }}</strong>
+                  <label>
+                    Отступ (%):
+                    <input type="number" step="0.01" name="tp-offset" value="{{ tp.offset_percent }}" required />
+                  </label>
+                  <label>
+                    Объём (%):
+                    <input type="number" step="0.01" name="tp-volume" value="{{ tp.volume_percent }}" required />
+                  </label>
+                </div>
+                {% endfor %}
+              </fieldset>
+
+              <fieldset class="stop-loss-container">
+                <legend>Стоп-лоссы</legend>
+                <div class="stop-loss-list">
+                  {% for sl in instrument.config.stop_losses %}
+                  <div class="stop-loss-row">
+                    <label>
+                      Отступ (%):
+                      <input type="number" step="0.01" name="sl-offset" value="{{ sl.offset_percent }}" required />
+                    </label>
+                    <label>
+                      Объём (%):
+                      <input type="number" step="0.01" name="sl-volume" value="{{ sl.volume_percent }}" required />
+                    </label>
+                    <button type="button" class="remove-stop">×</button>
+                  </div>
+                  {% endfor %}
+                </div>
+                <button type="button" class="add-stop">Добавить стоп</button>
+              </fieldset>
+
+              <fieldset class="dca-settings">
+                <legend>Доливка после TP1</legend>
+                <label class="checkbox">
+                  <input type="checkbox" name="dca-enabled" {% if instrument.config.tp1_dca.enabled %}checked{% endif %} />
+                  Использовать доливку после TP1
+                </label>
+                <div class="dca-fields">
+                  <label>
+                    Отступ (%):
+                    <input type="number" step="0.01" name="dca-offset" value="{{ instrument.config.tp1_dca.offset_percent or '' }}" />
+                  </label>
+                  <label>
+                    Объём (контракты):
+                    <input type="number" step="0.01" name="dca-quantity" value="{{ instrument.config.tp1_dca.quantity or '' }}" />
+                  </label>
+                </div>
+              </fieldset>
+
+              <footer class="form-actions">
+                <button type="submit" class="primary">Сохранить настройки</button>
+              </footer>
+            </form>
+          </section>
+
+          <section class="tab-content status" data-tab="status">
+            <div class="status-panel">
+              <p>Состояние: <span class="status-text">{{ 'Работает' if instrument.is_running else 'Остановлен' }}</span></p>
+              <div class="positions">
+                <h3>Размер позиции</h3>
+                <ul>
+                  <li>Long: <span data-position="LONG">{{ instrument.positions['LONG'] }}</span></li>
+                  <li>Short: <span data-position="SHORT">{{ instrument.positions['SHORT'] }}</span></li>
+                </ul>
+              </div>
+              <div class="status-actions">
+                <button class="primary start">Старт</button>
+                <button class="secondary stop">Стоп</button>
+                <button class="danger close">Закрыть всё вручную</button>
+              </div>
+            </div>
+          </section>
+
+          <section class="tab-content orders" data-tab="orders">
+            <div class="orders-list">
+              <h3>Активные ордера</h3>
+              <table class="open-orders">
+                <thead>
+                  <tr><th>ID</th><th>Тип</th><th>Сторона</th><th>Кол-во</th><th>Статус</th></tr>
+                </thead>
+                <tbody>
+                  {% for order in instrument.open_orders %}
+                  <tr>
+                    <td>{{ order.id }}</td>
+                    <td>{{ order.type }}</td>
+                    <td>{{ order.side }}</td>
+                    <td>{{ order.quantity }}</td>
+                    <td>{{ order.status }}</td>
+                  </tr>
+                  {% endfor %}
+                </tbody>
+              </table>
+
+              <h3>Доливки</h3>
+              <table class="dca-table">
+                <thead>
+                  <tr><th>ID</th><th>Сторона</th><th>Кол-во</th><th>Статус</th></tr>
+                </thead>
+                <tbody>
+                  {% for order in instrument.dca_orders %}
+                  <tr>
+                    <td>{{ order.id }}</td>
+                    <td>{{ order.side }}</td>
+                    <td>{{ order.quantity }}</td>
+                    <td>{{ order.status }}</td>
+                  </tr>
+                  {% endfor %}
+                </tbody>
+              </table>
+            </div>
+          </section>
+
+          <section class="tab-content logs" data-tab="logs">
+            <div class="log-list">
+              <button type="button" class="refresh primary">Обновить</button>
+              <ul>
+                {% for entry in instrument.logs | reverse %}
+                <li>
+                  <time>{{ entry.timestamp }}</time>
+                  <span class="level level-{{ entry.level.lower() }}">{{ entry.level }}</span>
+                  <span class="message">{{ entry.message }}</span>
+                </li>
+                {% endfor %}
+              </ul>
+            </div>
+          </section>
+        </article>
+        {% endfor %}
+      </section>
+    </main>
+
+    <script src="/static/app.js"></script>
+  </body>
+</html>

--- a/hedgbot/bot.py
+++ b/hedgbot/bot.py
@@ -1,0 +1,309 @@
+"""Core bot logic for managing a hedged position."""
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Dict, List
+
+from .exchange.bybit_client import MockBybitClient, OrderRequest
+from .models import (
+    InstrumentConfig,
+    InstrumentState,
+    LogEntry,
+    LogLevel,
+    Order,
+    OrderSide,
+    OrderStatus,
+    OrderType,
+    StopLossLevel,
+    TakeProfitLevel,
+)
+
+
+@dataclass
+class _RuntimeState:
+    """Mutable runtime state maintained while the bot is active."""
+
+    is_running: bool = False
+    positions: Dict[OrderSide, float] = None  # type: ignore[assignment]
+    open_orders: List[Order] = None  # type: ignore[assignment]
+    dca_orders: List[Order] = None  # type: ignore[assignment]
+    logs: List[LogEntry] = None  # type: ignore[assignment]
+
+    def __post_init__(self) -> None:
+        self.positions = {OrderSide.LONG: 0.0, OrderSide.SHORT: 0.0}
+        self.open_orders = []
+        self.dca_orders = []
+        self.logs = []
+
+
+class HedgeBot:
+    """Encapsulates the hedging automation for a single instrument."""
+
+    def __init__(
+        self,
+        config: InstrumentConfig,
+        client: MockBybitClient | None = None,
+    ) -> None:
+        self._config = config
+        self._client = client or MockBybitClient()
+        self._lock = asyncio.Lock()
+        self._state = _RuntimeState()
+
+    @property
+    def config(self) -> InstrumentConfig:
+        return self._config
+
+    async def update_config(self, config: InstrumentConfig) -> None:
+        """Replace the configuration. Allowed only when stopped."""
+
+        async with self._lock:
+            if self._state.is_running:
+                raise RuntimeError("Cannot change configuration while bot is running")
+            self._config = config
+            self._append_log("Configuration updated")
+
+    async def start(self) -> None:
+        """Start the strategy by opening both directions."""
+
+        async with self._lock:
+            if self._state.is_running:
+                raise RuntimeError("Bot already running")
+
+            await self._create_entry_orders()
+            await self._create_take_profits()
+            await self._create_stop_losses()
+
+            self._state.positions[OrderSide.LONG] = self._config.entry_amount
+            self._state.positions[OrderSide.SHORT] = self._config.entry_amount
+            self._state.is_running = True
+            self._append_log("Bot started: entry orders placed for both sides")
+
+    async def stop(self) -> None:
+        """Stop the bot and cancel all outstanding orders."""
+
+        async with self._lock:
+            if not self._state.is_running:
+                return
+
+            await self._client.cancel_all(self._config.symbol)
+            self._reset_runtime(clear_logs=False)
+            self._append_log("Bot stopped and orders cancelled", level=LogLevel.WARNING)
+
+    async def close_all(self) -> None:
+        """Close both sides at market and reset the state."""
+
+        async with self._lock:
+            if not self._state.is_running:
+                return
+
+            for side in (OrderSide.LONG, OrderSide.SHORT):
+                await self._client.close_position(self._config.symbol, side)
+                self._state.positions[side] = 0.0
+
+            await self._client.cancel_all(self._config.symbol)
+            self._reset_runtime(clear_logs=False)
+            self._append_log("Positions closed manually", level=LogLevel.WARNING)
+
+    async def trigger_take_profit(self, side: OrderSide, level_index: int) -> None:
+        """Simulate take-profit fill to test the workflow."""
+
+        async with self._lock:
+            self._ensure_running()
+            level = self._config.take_profits[level_index]
+            await self._handle_take_profit(side, level)
+
+    async def trigger_stop_loss(self, side: OrderSide, level_index: int) -> None:
+        """Simulate stop-loss fill to test the workflow."""
+
+        async with self._lock:
+            self._ensure_running()
+            level = self._config.stop_losses[level_index]
+            await self._handle_stop_loss(side, level_index, level)
+
+    async def trigger_dca_fill(self, order_id: str) -> None:
+        """Mark a DCA order as filled and restore the position size."""
+
+        async with self._lock:
+            for order in self._state.dca_orders:
+                if order.id == order_id and order.status == OrderStatus.PENDING:
+                    order.status = OrderStatus.FILLED
+                    self._state.positions[order.side] += order.quantity
+                    self._append_log(
+                        f"DCA order {order.id} filled for {order.side.value}")
+                    return
+            raise ValueError(f"DCA order {order_id} not found or already filled")
+
+    def snapshot(self) -> InstrumentState:
+        """Return a serialisable snapshot of the current state."""
+
+        return InstrumentState(
+            symbol=self._config.symbol,
+            is_running=self._state.is_running,
+            positions=self._state.positions.copy(),
+            open_orders=list(self._state.open_orders),
+            dca_orders=list(self._state.dca_orders),
+            logs=list(self._state.logs),
+            config=self._config,
+        )
+
+    # Internal helpers -------------------------------------------------
+    def _reset_runtime(self, clear_logs: bool = True) -> None:
+        logs = [] if clear_logs else list(self._state.logs)
+        self._state = _RuntimeState()
+        self._state.logs = logs
+
+    def _ensure_running(self) -> None:
+        if not self._state.is_running:
+            raise RuntimeError("Bot must be running to handle events")
+
+    def _append_log(self, message: str, level: LogLevel = LogLevel.INFO) -> None:
+        self._state.logs.append(LogEntry(message=message, level=level))
+
+    async def _create_entry_orders(self) -> None:
+        for side in (OrderSide.LONG, OrderSide.SHORT):
+            order = await self._client.place_order(
+                OrderRequest(
+                    symbol=self._config.symbol,
+                    side=side,
+                    order_type=OrderType.ENTRY,
+                    quantity=self._config.entry_amount,
+                )
+            )
+            self._state.open_orders.append(order)
+            self._append_log(
+                f"Entry order created for {side.value} with size {order.quantity}")
+
+    async def _create_take_profits(self) -> None:
+        for level in self._config.take_profits:
+            for side in (OrderSide.LONG, OrderSide.SHORT):
+                quantity = self._config.entry_amount * level.volume_percent / 100
+                order = await self._client.place_order(
+                    OrderRequest(
+                        symbol=self._config.symbol,
+                        side=side,
+                        order_type=OrderType.TAKE_PROFIT,
+                        quantity=quantity,
+                    )
+                )
+                self._state.open_orders.append(order)
+                self._append_log(
+                    f"{level.label} order placed for {side.value} ({quantity} contracts)")
+
+    async def _create_stop_losses(self) -> None:
+        for level in self._config.stop_losses:
+            for side in (OrderSide.LONG, OrderSide.SHORT):
+                quantity = self._config.entry_amount * level.volume_percent / 100
+                order = await self._client.place_order(
+                    OrderRequest(
+                        symbol=self._config.symbol,
+                        side=side,
+                        order_type=OrderType.STOP_LOSS,
+                        quantity=quantity,
+                    )
+                )
+                self._state.open_orders.append(order)
+                self._append_log(
+                    f"Stop-loss order placed for {side.value} ({quantity} contracts)")
+
+    async def _handle_take_profit(
+        self,
+        side: OrderSide,
+        level: TakeProfitLevel,
+    ) -> None:
+        quantity = self._config.entry_amount * level.volume_percent / 100
+        self._state.positions[side] = max(
+            0.0, self._state.positions[side] - quantity
+        )
+
+        for order in self._state.open_orders:
+            if (
+                order.type == OrderType.TAKE_PROFIT
+                and order.side == side
+                and order.status == OrderStatus.PENDING
+            ):
+                order.status = OrderStatus.FILLED
+                break
+
+        self._append_log(
+            f"{level.label} hit for {side.value}, closed {quantity} contracts")
+
+        if level.label == "TP1":
+            await self._maybe_create_tp1_dca(side)
+        else:
+            await self._finalise_trade()
+
+    async def _handle_stop_loss(
+        self,
+        side: OrderSide,
+        level_index: int,
+        level: StopLossLevel,
+    ) -> None:
+        quantity = self._config.entry_amount * level.volume_percent / 100
+        self._state.positions[side] = max(
+            0.0, self._state.positions[side] - quantity
+        )
+
+        for order in self._state.open_orders:
+            if (
+                order.type == OrderType.STOP_LOSS
+                and order.side == side
+                and order.status == OrderStatus.PENDING
+            ):
+                order.status = OrderStatus.FILLED
+                break
+
+        self._append_log(
+            f"Stop-loss level {level_index + 1} triggered for {side.value},"
+            f" closed {quantity} contracts",
+        )
+
+        await self._create_entry_dca(side, quantity)
+
+    async def _maybe_create_tp1_dca(self, side: OrderSide) -> None:
+        if not self._config.tp1_dca.enabled:
+            return
+        quantity = self._config.tp1_dca.quantity or 0.0
+        if quantity <= 0:
+            return
+        offset = self._config.tp1_dca.offset_percent or 0.0
+        order = await self._client.place_order(
+            OrderRequest(
+                symbol=self._config.symbol,
+                side=side,
+                order_type=OrderType.DCA,
+                quantity=quantity,
+            )
+        )
+        self._state.dca_orders.append(order)
+        self._append_log(
+            f"TP1 DCA order placed for {side.value} ({order.quantity} contracts, offset {offset:.2f}%)"
+        )
+
+    async def _create_entry_dca(self, side: OrderSide, quantity: float) -> None:
+        if quantity <= 0:
+            return
+        order = await self._client.place_order(
+            OrderRequest(
+                symbol=self._config.symbol,
+                side=side,
+                order_type=OrderType.DCA,
+                quantity=quantity,
+            )
+        )
+        self._state.dca_orders.append(order)
+        self._append_log(
+            f"Entry DCA order placed for {side.value} ({quantity} contracts)"
+        )
+
+    async def _finalise_trade(self) -> None:
+        for order in self._state.open_orders:
+            if order.status == OrderStatus.PENDING:
+                order.status = OrderStatus.CANCELLED
+        self._state.positions[OrderSide.LONG] = 0.0
+        self._state.positions[OrderSide.SHORT] = 0.0
+        self._state.is_running = False
+        self._append_log("Final TP reached. Trade cycle completed.")
+
+
+__all__ = ["HedgeBot"]

--- a/hedgbot/config.py
+++ b/hedgbot/config.py
@@ -1,0 +1,25 @@
+"""Application configuration utilities."""
+from functools import lru_cache
+from pydantic import BaseSettings, Field
+
+
+class Settings(BaseSettings):
+    """Runtime settings loaded from the environment."""
+
+    bybit_api_key: str = Field(env="BYBIT_API_KEY", default="")
+    bybit_api_secret: str = Field(env="BYBIT_API_SECRET", default="")
+    bybit_base_url: str = Field(
+        env="BYBIT_BASE_URL",
+        default="https://api.bybit.com",
+    )
+
+    class Config:
+        env_file = ".env"
+        env_file_encoding = "utf-8"
+
+
+@lru_cache()
+def get_settings() -> Settings:
+    """Return cached application settings."""
+
+    return Settings()

--- a/hedgbot/exchange/bybit_client.py
+++ b/hedgbot/exchange/bybit_client.py
@@ -1,0 +1,58 @@
+"""A lightweight Bybit HTTP client abstraction."""
+from __future__ import annotations
+
+import asyncio
+import itertools
+from dataclasses import dataclass
+from typing import Optional
+
+from ..models import Order, OrderSide, OrderStatus, OrderType
+
+
+@dataclass
+class OrderRequest:
+    """Request payload used by the mock client."""
+
+    symbol: str
+    side: OrderSide
+    order_type: OrderType
+    quantity: float
+    price: Optional[float] = None
+
+
+class MockBybitClient:
+    """A stand-in for the real Bybit client.
+
+    The mock is intentionally simple: it records the orders that would have been
+    placed and immediately returns synthetic identifiers. This keeps the
+    application fully testable without requiring real exchange access.
+    """
+
+    _id_counter = itertools.count(1)
+
+    async def place_order(self, request: OrderRequest) -> Order:
+        """Return a fake order object."""
+
+        await asyncio.sleep(0)  # allow context switch in async flows
+        order_id = f"{request.order_type.value}-{next(self._id_counter)}"
+        return Order(
+            id=order_id,
+            type=request.order_type,
+            side=request.side,
+            price=request.price,
+            quantity=request.quantity,
+            status=OrderStatus.PENDING,
+        )
+
+    async def cancel_all(self, symbol: str) -> None:
+        """Pretend to cancel orders on the exchange."""
+
+        await asyncio.sleep(0)
+
+    async def close_position(self, symbol: str, side: OrderSide) -> None:
+        """Pretend to close a position at market."""
+
+        await asyncio.sleep(0)
+
+
+__all__ = ["MockBybitClient", "OrderRequest"]

--- a/hedgbot/manager.py
+++ b/hedgbot/manager.py
@@ -1,0 +1,73 @@
+"""Fleet management for multiple Hedg-Bot instances."""
+from __future__ import annotations
+
+import asyncio
+from typing import Dict, Iterable
+
+from .bot import HedgeBot
+from .models import InstrumentConfig, ManagerState, TakeProfitLevel
+
+
+def default_config(symbol: str) -> InstrumentConfig:
+    """Return a sensible default configuration for a symbol."""
+
+    return InstrumentConfig(
+        symbol=symbol,
+        entry_amount=100.0,
+        take_profits=[
+            TakeProfitLevel(label="TP1", offset_percent=0.5, volume_percent=50),
+            TakeProfitLevel(label="TP2", offset_percent=1.0, volume_percent=50),
+        ],
+        stop_losses=[],
+    )
+
+
+class BotManager:
+    """Coordinates a set of bots and exposes convenience helpers."""
+
+    def __init__(self, configs: Iterable[InstrumentConfig]) -> None:
+        self._bots: Dict[str, HedgeBot] = {
+            config.symbol: HedgeBot(config) for config in configs
+        }
+        self._lock = asyncio.Lock()
+
+    def symbols(self) -> list[str]:
+        """Return the list of registered symbols."""
+
+        return list(self._bots.keys())
+
+    def get_bot(self, symbol: str) -> HedgeBot:
+        try:
+            return self._bots[symbol]
+        except KeyError as exc:
+            raise KeyError(f"Unknown instrument {symbol}") from exc
+
+    async def start(self, symbol: str) -> None:
+        await self.get_bot(symbol).start()
+
+    async def stop(self, symbol: str) -> None:
+        await self.get_bot(symbol).stop()
+
+    async def close(self, symbol: str) -> None:
+        await self.get_bot(symbol).close_all()
+
+    async def start_all(self) -> None:
+        async with self._lock:
+            await asyncio.gather(
+                *(bot.start() for bot in self._bots.values() if not bot.snapshot().is_running)
+            )
+
+    async def stop_all(self) -> None:
+        async with self._lock:
+            await asyncio.gather(*(bot.stop() for bot in self._bots.values()))
+
+    def snapshot(self) -> ManagerState:
+        return ManagerState(
+            instruments=[bot.snapshot() for bot in self._bots.values()]
+        )
+
+    async def update_config(self, symbol: str, config: InstrumentConfig) -> None:
+        await self.get_bot(symbol).update_config(config)
+
+
+__all__ = ["BotManager", "default_config"]

--- a/hedgbot/models.py
+++ b/hedgbot/models.py
@@ -1,0 +1,143 @@
+"""Domain models for Hedg-Bot."""
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+from typing import List, Optional
+
+from pydantic import BaseModel, Field, validator
+
+
+class OrderSide(str, Enum):
+    """Represents the order side."""
+
+    LONG = "LONG"
+    SHORT = "SHORT"
+
+
+class OrderType(str, Enum):
+    """Supported order types."""
+
+    ENTRY = "ENTRY"
+    TAKE_PROFIT = "TAKE_PROFIT"
+    STOP_LOSS = "STOP_LOSS"
+    DCA = "DCA"
+
+
+class OrderStatus(str, Enum):
+    """High-level order status."""
+
+    PENDING = "PENDING"
+    FILLED = "FILLED"
+    CANCELLED = "CANCELLED"
+
+
+class LogLevel(str, Enum):
+    """Log severity."""
+
+    INFO = "INFO"
+    WARNING = "WARNING"
+    ERROR = "ERROR"
+
+
+class TakeProfitLevel(BaseModel):
+    """Take-profit description."""
+
+    label: str = Field(..., description="Human readable name (TP1/TP2).")
+    offset_percent: float = Field(
+        ..., gt=0, description="Distance from the entry in percent.")
+    volume_percent: float = Field(
+        ..., gt=0, le=100, description="Portion of the initial volume to close.")
+
+
+class StopLossLevel(BaseModel):
+    """Stop-loss configuration."""
+
+    offset_percent: float = Field(
+        ..., gt=0, description="Distance from the entry in percent.")
+    volume_percent: float = Field(
+        ..., gt=0, le=100, description="Portion of the initial volume to close.")
+
+
+class TP1DcaSettings(BaseModel):
+    """Settings for DCA order created after TP1."""
+
+    enabled: bool = False
+    offset_percent: Optional[float] = Field(
+        None,
+        gt=0,
+        description="Distance from TP1 fill price for the limit order.",
+    )
+    quantity: Optional[float] = Field(
+        None,
+        gt=0,
+        description="Absolute size of the DCA order in contracts.",
+    )
+
+    @validator("offset_percent", always=True)
+    def _validate_offset(cls, value, values):  # type: ignore[override]
+        enabled = values.get("enabled")
+        if enabled and value is None:
+            raise ValueError("Offset percent must be set when DCA is enabled")
+        return value
+
+    @validator("quantity", always=True)
+    def _validate_quantity(cls, value, values):  # type: ignore[override]
+        enabled = values.get("enabled")
+        if enabled and value is None:
+            raise ValueError("Quantity must be set when DCA is enabled")
+        return value
+
+
+class InstrumentConfig(BaseModel):
+    """Complete instrument configuration."""
+
+    symbol: str
+    entry_amount: float = Field(..., gt=0, description="Entry size per side in USDT")
+    take_profits: List[TakeProfitLevel] = Field(..., min_items=2, max_items=2)
+    stop_losses: List[StopLossLevel] = Field(default_factory=list, max_items=10)
+    tp1_dca: TP1DcaSettings = Field(default_factory=TP1DcaSettings)
+
+    @validator("take_profits")
+    def _validate_tp_labels(cls, value: List[TakeProfitLevel]) -> List[TakeProfitLevel]:
+        labels = [level.label for level in value]
+        if labels != ["TP1", "TP2"]:
+            raise ValueError("Two take-profit levels TP1 and TP2 must be provided")
+        return value
+
+
+class Order(BaseModel):
+    """Simplified order representation."""
+
+    id: str
+    type: OrderType
+    side: OrderSide
+    price: Optional[float]
+    quantity: float
+    status: OrderStatus = OrderStatus.PENDING
+
+
+class LogEntry(BaseModel):
+    """Structured log entry."""
+
+    timestamp: datetime = Field(default_factory=datetime.utcnow)
+    level: LogLevel = LogLevel.INFO
+    message: str
+
+
+class InstrumentState(BaseModel):
+    """Runtime state for a particular instrument."""
+
+    symbol: str
+    is_running: bool
+    positions: dict[OrderSide, float]
+    open_orders: List[Order]
+    dca_orders: List[Order]
+    logs: List[LogEntry]
+    config: InstrumentConfig
+
+
+class ManagerState(BaseModel):
+    """Snapshot of the entire bot fleet."""
+
+    instruments: List[InstrumentState]

--- a/main.py
+++ b/main.py
@@ -1,0 +1,175 @@
+"""FastAPI application exposing Hedg-Bot controls and UI."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from fastapi import Body, FastAPI, HTTPException, Request
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import HTMLResponse
+from fastapi.staticfiles import StaticFiles
+from fastapi.templating import Jinja2Templates
+
+from hedgbot.config import get_settings
+from hedgbot.manager import BotManager, default_config
+from hedgbot.models import InstrumentConfig, InstrumentState, ManagerState, OrderSide
+
+app = FastAPI(title="Hedg-Bot")
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+BASE_DIR = Path(__file__).parent
+TEMPLATES_DIR = BASE_DIR / "hedgbot" / "app" / "templates"
+STATIC_DIR = BASE_DIR / "hedgbot" / "app" / "static"
+
+templates = Jinja2Templates(directory=str(TEMPLATES_DIR))
+app.mount("/static", StaticFiles(directory=str(STATIC_DIR)), name="static")
+
+# Initialise configuration and bots
+get_settings()  # ensure .env is parsed early
+_default_symbols = ["BTCUSDT", "ETHUSDT", "SOLUSDT", "XRPUSDT"]
+manager = BotManager(default_config(symbol) for symbol in _default_symbols)
+
+
+@app.get("/", response_class=HTMLResponse)
+async def index(request: Request) -> HTMLResponse:
+    """Render the control panel."""
+
+    state = manager.snapshot()
+    return templates.TemplateResponse(
+        "index.html", {"request": request, "state": state}
+    )
+
+
+@app.get("/api/instruments", response_model=ManagerState)
+async def get_instruments() -> ManagerState:
+    return manager.snapshot()
+
+
+@app.get("/api/instruments/{symbol}", response_model=InstrumentState)
+async def get_instrument(symbol: str) -> InstrumentState:
+    try:
+        return manager.get_bot(symbol).snapshot()
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
+@app.post("/api/instruments/{symbol}/config", response_model=InstrumentState)
+async def update_config(symbol: str, payload: InstrumentConfig) -> InstrumentState:
+    if payload.symbol != symbol:
+        raise HTTPException(
+            status_code=400,
+            detail="Symbol in payload does not match URL",
+        )
+    try:
+        await manager.update_config(symbol, payload)
+        return manager.get_bot(symbol).snapshot()
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except RuntimeError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+
+
+@app.post("/api/instruments/{symbol}/start", response_model=InstrumentState)
+async def start_bot(symbol: str) -> InstrumentState:
+    try:
+        await manager.start(symbol)
+        return manager.get_bot(symbol).snapshot()
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except RuntimeError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+
+
+@app.post("/api/instruments/{symbol}/stop", response_model=InstrumentState)
+async def stop_bot(symbol: str) -> InstrumentState:
+    try:
+        await manager.stop(symbol)
+        return manager.get_bot(symbol).snapshot()
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
+@app.post("/api/instruments/{symbol}/close", response_model=InstrumentState)
+async def close_bot(symbol: str) -> InstrumentState:
+    try:
+        await manager.close(symbol)
+        return manager.get_bot(symbol).snapshot()
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
+@app.post("/api/instruments/start_all", response_model=ManagerState)
+async def start_all() -> ManagerState:
+    await manager.start_all()
+    return manager.snapshot()
+
+
+@app.post("/api/instruments/stop_all", response_model=ManagerState)
+async def stop_all() -> ManagerState:
+    await manager.stop_all()
+    return manager.snapshot()
+
+
+@app.post("/api/instruments/{symbol}/simulate/tp/{level}", response_model=InstrumentState)
+async def simulate_tp(
+    symbol: str,
+    level: int,
+    side: OrderSide = Body(..., embed=True, description="Side to simulate"),
+) -> InstrumentState:
+    try:
+        bot = manager.get_bot(symbol)
+        await bot.trigger_take_profit(side, level)
+        return bot.snapshot()
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except RuntimeError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except IndexError:
+        raise HTTPException(status_code=400, detail="Invalid TP level index")
+
+
+@app.post("/api/instruments/{symbol}/simulate/sl/{level}", response_model=InstrumentState)
+async def simulate_sl(
+    symbol: str,
+    level: int,
+    side: OrderSide = Body(..., embed=True, description="Side to simulate"),
+) -> InstrumentState:
+    try:
+        bot = manager.get_bot(symbol)
+        await bot.trigger_stop_loss(side, level)
+        return bot.snapshot()
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except RuntimeError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except IndexError:
+        raise HTTPException(status_code=400, detail="Invalid SL level index")
+
+
+@app.post("/api/instruments/{symbol}/simulate/dca", response_model=InstrumentState)
+async def simulate_dca_fill(
+    symbol: str,
+    order_id: str = Body(..., embed=True, description="DCA order identifier"),
+) -> InstrumentState:
+    try:
+        bot = manager.get_bot(symbol)
+        await bot.trigger_dca_fill(order_id)
+        return bot.snapshot()
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@app.get("/health")
+async def healthcheck() -> dict[str, Any]:
+    return {"status": "ok"}
+
+
+__all__ = ["app"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+fastapi==0.109.2
+uvicorn[standard]==0.27.1
+pydantic==1.10.14
+python-dotenv==1.0.1
+jinja2==3.1.3


### PR DESCRIPTION
## Summary
- add FastAPI application that exposes REST endpoints for configuring and controlling hedged trading bots and serves a management UI
- implement core hedging bot engine, state models, and Bybit client abstraction to simulate TP, SL, and DCA flows per specification
- create web interface with styling and JavaScript to manage instruments, configure TP/SL/DCA parameters, and review runtime logs and orders

## Testing
- python -m compileall .


------
https://chatgpt.com/codex/tasks/task_e_68d15b6c0734832a9f09cd9fb0b3f6ca