### PR TITLE
Implement Textual-based hedge trading interface

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,0 +1,5 @@
+from hedgebot.ui.app import run_app
+
+
+if __name__ == "__main__":
+    run_app()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pybit==5.11.0
 python-dotenv==1.1.1
+textual==6.1.0

--- a/src/hedgebot/__init__.py
+++ b/src/hedgebot/__init__.py
@@ -1,0 +1,3 @@
+from .ui.app import run_app
+
+__all__ = ["run_app"]

--- a/src/hedgebot/bybit_client.py
+++ b/src/hedgebot/bybit_client.py
@@ -1,0 +1,349 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import uuid
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Tuple
+
+from dotenv import load_dotenv
+from pybit.unified_trading import HTTP
+
+
+def _str_to_bool(v: Optional[str]) -> bool:
+    return (v or "").strip().lower() in {"1", "true", "yes", "y", "on"}
+
+
+@dataclass(slots=True)
+class SymbolFilters:
+    qty_step: float
+    min_qty: float
+    max_qty: float
+    tick_size: float
+
+
+class BybitClient:
+    """Асинхронный обёртка над REST-интерфейсом pybit."""
+
+    def __init__(self) -> None:
+        load_dotenv()
+        api_key = os.getenv("BYBIT_API_KEY")
+        api_secret = os.getenv("BYBIT_API_SECRET")
+        if not api_key or not api_secret:
+            raise RuntimeError("Не найдены ключи BYBIT_API_KEY/BYBIT_API_SECRET в .env")
+        testnet = _str_to_bool(os.getenv("BYBIT_TESTNET"))
+        self._http = HTTP(testnet=testnet, api_key=api_key, api_secret=api_secret,
+                           timeout=10_000, recv_window=5_000)
+        self._lock = asyncio.Lock()
+
+    async def _call(self, func, *args, **kwargs):
+        async with self._lock:
+            return await asyncio.to_thread(func, *args, **kwargs)
+
+    # ------------------------------------------------------------------
+    # Общие проверки и данные
+    # ------------------------------------------------------------------
+    async def ensure_symbol_trading(self, symbol: str) -> Tuple[bool, str]:
+        return await self._call(self._check_symbol_status, symbol)
+
+    async def ensure_hedge_mode(self, symbol: str) -> None:
+        enabled = await self._call(self._check_hedge_mode, symbol)
+        if not enabled:
+            await self._call(self._enable_hedge_mode, symbol)
+
+    async def get_symbol_filters(self, symbol: str) -> SymbolFilters:
+        return await self._call(self._get_symbol_filters, symbol)
+
+    async def get_open_orders(self, symbol: str) -> List[dict]:
+        return await self._call(self._get_open_orders, symbol)
+
+    async def get_order_info(self, symbol: str, order_id: str) -> Optional[dict]:
+        return await self._call(self._get_order_info, symbol, order_id)
+
+    async def get_positions(self, symbol: str) -> List[dict]:
+        return await self._call(self._get_positions, symbol)
+
+    async def get_position_side(self, symbol: str, side: str) -> Optional[dict]:
+        return await self._call(self._get_position_side, symbol, side)
+
+    # ------------------------------------------------------------------
+    # Управление ордерами
+    # ------------------------------------------------------------------
+    async def place_conditional_market_order(
+        self,
+        symbol: str,
+        side: str,
+        qty: str,
+        trigger_price: str,
+        trigger_direction: int,
+        trigger_by: str = "LastPrice",
+        position_idx: Optional[int] = None,
+        reduce_only: bool = False,
+        close_on_trigger: bool = False,
+        order_link_id: Optional[str] = None,
+    ) -> str:
+        return await self._call(
+            self._place_conditional_market_order,
+            symbol,
+            side,
+            qty,
+            trigger_price,
+            trigger_direction,
+            trigger_by,
+            position_idx,
+            reduce_only,
+            close_on_trigger,
+            order_link_id,
+        )
+
+    async def place_limit_order(
+        self,
+        symbol: str,
+        side: str,
+        qty: str,
+        price: str,
+        position_idx: Optional[int] = None,
+        time_in_force: str = "GTC",
+        reduce_only: bool = True,
+        order_link_id: Optional[str] = None,
+    ) -> str:
+        return await self._call(
+            self._place_limit_order,
+            symbol,
+            side,
+            qty,
+            price,
+            position_idx,
+            time_in_force,
+            reduce_only,
+            order_link_id,
+        )
+
+    async def cancel_order(self, symbol: str, order_id: str) -> None:
+        await self._call(self._cancel_order, symbol, order_id)
+
+    async def cancel_all_orders(self, symbol: str) -> None:
+        await self._call(self._cancel_all_orders, symbol)
+
+    async def close_position_market(self, symbol: str, side: str) -> Optional[str]:
+        return await self._call(self._close_position_market, symbol, side)
+
+    # ------------------------------------------------------------------
+    # Реализация синхронных методов
+    # ------------------------------------------------------------------
+    def _check_symbol_status(self, symbol: str) -> Tuple[bool, str]:
+        resp = self._http.get_instruments_info(category="linear", symbol=symbol)
+        if not isinstance(resp, dict) or resp.get("retCode") != 0:
+            raise RuntimeError(f"Bybit API error: {resp}")
+        instruments = resp["result"].get("list") or []
+        if not instruments:
+            return False, "NotFound"
+        status = instruments[0].get("status", "Unknown")
+        return status == "Trading", status
+
+    def _get_symbol_filters(self, symbol: str) -> SymbolFilters:
+        resp = self._http.get_instruments_info(category="linear", symbol=symbol)
+        if not isinstance(resp, dict) or resp.get("retCode") != 0:
+            raise RuntimeError(f"Bybit API error: {resp}")
+        instruments = resp["result"].get("list") or []
+        if not instruments:
+            raise RuntimeError("Символ не найден")
+        inst = instruments[0]
+        lot = inst.get("lotSizeFilter", {})
+        price = inst.get("priceFilter", {})
+        return SymbolFilters(
+            qty_step=float(lot.get("qtyStep", "0.0")),
+            min_qty=float(lot.get("minOrderQty", "0.0")),
+            max_qty=float(lot.get("maxOrderQty", "0.0")),
+            tick_size=float(price.get("tickSize", "0.0")),
+        )
+
+    def _check_hedge_mode(self, symbol: str) -> bool:
+        resp = self._http.get_positions(category="linear", symbol=symbol)
+        if not isinstance(resp, dict) or resp.get("retCode") != 0:
+            raise RuntimeError(f"Bybit API error: {resp}")
+        items = resp["result"].get("list") or []
+        idxs = {int(i.get("positionIdx", 0)) for i in items}
+        return 1 in idxs and 2 in idxs
+
+    def _enable_hedge_mode(self, symbol: str) -> None:
+        resp = self._http.switch_position_mode(category="linear", symbol=symbol, mode=3)
+        if not isinstance(resp, dict) or resp.get("retCode") != 0:
+            raise RuntimeError(f"Не удалось включить хедж-режим: {resp}")
+
+    def _get_open_orders(self, symbol: str) -> List[dict]:
+        resp = self._http.get_open_orders(category="linear", symbol=symbol)
+        if not isinstance(resp, dict) or resp.get("retCode") != 0:
+            raise RuntimeError(f"Bybit API error: {resp}")
+        return resp["result"].get("list") or []
+
+    def _get_order_info(self, symbol: str, order_id: str) -> Optional[dict]:
+        # direct lookup
+        resp = self._http.get_open_orders(category="linear", symbol=symbol, orderId=order_id)
+        if isinstance(resp, dict) and resp.get("retCode") == 0:
+            items = resp.get("result", {}).get("list") or []
+            if items:
+                return items[0]
+        # search open orders list
+        resp_open = self._http.get_open_orders(category="linear", symbol=symbol)
+        if isinstance(resp_open, dict) and resp_open.get("retCode") == 0:
+            for o in resp_open.get("result", {}).get("list") or []:
+                if o.get("orderId") == order_id:
+                    return o
+        # lookup history
+        cursor = None
+        pages = 0
+        while pages < 6:
+            kwargs: Dict[str, Any] = {"category": "linear", "symbol": symbol}
+            if cursor:
+                kwargs["cursor"] = cursor
+            kwargs["orderId"] = order_id
+            resp_hist = self._http.get_order_history(**kwargs)
+            if not isinstance(resp_hist, dict) or resp_hist.get("retCode") != 0:
+                raise RuntimeError(f"Bybit API error: {resp_hist}")
+            items = resp_hist.get("result", {}).get("list") or []
+            for o in items:
+                if o.get("orderId") == order_id:
+                    return o
+            cursor = resp_hist.get("result", {}).get("nextPageCursor")
+            if not cursor:
+                break
+            pages += 1
+        return None
+
+    def _get_positions(self, symbol: str) -> List[dict]:
+        resp = self._http.get_positions(category="linear", symbol=symbol)
+        if not isinstance(resp, dict) or resp.get("retCode") != 0:
+            raise RuntimeError(f"Bybit API error: {resp}")
+        items = resp["result"].get("list") or []
+        return [p for p in items if float(p.get("size", "0") or 0) != 0]
+
+    def _get_position_side(self, symbol: str, side: str) -> Optional[dict]:
+        resp = self._http.get_positions(category="linear", symbol=symbol)
+        if not isinstance(resp, dict) or resp.get("retCode") != 0:
+            raise RuntimeError(f"Bybit API error: {resp}")
+        items = resp["result"].get("list") or []
+        side = side.lower().strip()
+        idx_map = {"long": 1, "short": 2}
+        idx = idx_map.get(side)
+        if idx is None:
+            raise ValueError("Сторона должна быть 'long' или 'short'")
+        for p in items:
+            if int(p.get("positionIdx", 0)) == idx:
+                if float(p.get("size", "0") or 0) != 0:
+                    return p
+                return None
+        return None
+
+    def _place_conditional_market_order(
+        self,
+        symbol: str,
+        side: str,
+        qty: str,
+        trigger_price: str,
+        trigger_direction: int,
+        trigger_by: str,
+        position_idx: Optional[int],
+        reduce_only: bool,
+        close_on_trigger: bool,
+        order_link_id: Optional[str],
+    ) -> str:
+        params: Dict[str, Any] = dict(
+            category="linear",
+            symbol=symbol,
+            side=side,
+            orderType="Market",
+            qty=qty,
+            triggerPrice=trigger_price,
+            triggerDirection=trigger_direction,
+            triggerBy=trigger_by,
+            stopOrderType="Stop",
+            timeInForce="IOC",
+            reduceOnly=reduce_only,
+            closeOnTrigger=close_on_trigger,
+            orderLinkId=order_link_id or f"cond-{uuid.uuid4().hex[:10]}",
+        )
+        if position_idx is not None:
+            params["positionIdx"] = position_idx
+        resp = self._http.place_order(**params)
+        if not isinstance(resp, dict) or resp.get("retCode") != 0:
+            raise RuntimeError(f"Bybit API error: {resp}")
+        return resp["result"]["orderId"]
+
+    def _place_limit_order(
+        self,
+        symbol: str,
+        side: str,
+        qty: str,
+        price: str,
+        position_idx: Optional[int],
+        time_in_force: str,
+        reduce_only: bool,
+        order_link_id: Optional[str],
+    ) -> str:
+        params: Dict[str, Any] = dict(
+            category="linear",
+            symbol=symbol,
+            side=side,
+            orderType="Limit",
+            qty=qty,
+            price=price,
+            timeInForce=time_in_force,
+            reduceOnly=reduce_only,
+            orderLinkId=order_link_id or f"limit-{uuid.uuid4().hex[:10]}",
+        )
+        if position_idx is not None:
+            params["positionIdx"] = position_idx
+        resp = self._http.place_order(**params)
+        if not isinstance(resp, dict) or resp.get("retCode") != 0:
+            raise RuntimeError(f"Bybit API error: {resp}")
+        return resp["result"]["orderId"]
+
+    def _cancel_order(self, symbol: str, order_id: str) -> None:
+        resp = self._http.cancel_order(category="linear", symbol=symbol, orderId=order_id)
+        if not isinstance(resp, dict) or resp.get("retCode") not in (0, 110001):
+            raise RuntimeError(f"Bybit API error: {resp}")
+
+    def _cancel_all_orders(self, symbol: str) -> None:
+        resp = self._http.cancel_all_orders(category="linear", symbol=symbol)
+        if not isinstance(resp, dict) or resp.get("retCode") not in (0, 110001):
+            raise RuntimeError(f"Bybit API error: {resp}")
+
+    def _close_position_market(self, symbol: str, side: str) -> Optional[str]:
+        resp = self._http.get_positions(category="linear", symbol=symbol)
+        if not isinstance(resp, dict) or resp.get("retCode") != 0:
+            raise RuntimeError(f"Bybit API error: {resp}")
+        items = resp["result"].get("list") or []
+        target = None
+        for p in items:
+            if float(p.get("size", "0") or 0) == 0:
+                continue
+            p_side = (p.get("side") or "").lower()
+            if side.lower() == "long" and p_side == "buy":
+                target = p
+                break
+            if side.lower() == "short" and p_side == "sell":
+                target = p
+                break
+        if not target:
+            return None
+        qty = target.get("size")
+        pos_idx = int(target.get("positionIdx", 0))
+        order_side = "Sell" if side.lower() == "long" else "Buy"
+        params: Dict[str, Any] = dict(
+            category="linear",
+            symbol=symbol,
+            side=order_side,
+            orderType="Market",
+            qty=qty,
+            timeInForce="IOC",
+            reduceOnly=True,
+            orderLinkId=f"close-{uuid.uuid4().hex[:10]}",
+        )
+        if pos_idx in (1, 2):
+            params["positionIdx"] = pos_idx
+        resp_order = self._http.place_order(**params)
+        if not isinstance(resp_order, dict) or resp_order.get("retCode") != 0:
+            raise RuntimeError(f"Bybit API error: {resp_order}")
+        return resp_order["result"]["orderId"]

--- a/src/hedgebot/config.py
+++ b/src/hedgebot/config.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List
+
+
+@dataclass(slots=True)
+class TakeProfitLevel:
+    """Настройки одного тейк-профита."""
+
+    offset_percent: float
+    quantity_percent: float
+
+    def clamp(self) -> "TakeProfitLevel":
+        return TakeProfitLevel(
+            offset_percent=float(self.offset_percent),
+            quantity_percent=float(self.quantity_percent),
+        )
+
+
+@dataclass(slots=True)
+class StopLossLevel:
+    """Настройки одного стоп-лосса."""
+
+    offset_percent: float
+    quantity_percent: float
+
+    def clamp(self) -> "StopLossLevel":
+        return StopLossLevel(
+            offset_percent=float(self.offset_percent),
+            quantity_percent=float(self.quantity_percent),
+        )
+
+
+@dataclass(slots=True)
+class RefillConfig:
+    """Настройки доливки позиции."""
+
+    enabled_after_tp1: bool = False
+    price_offset_percent: float = 0.0
+    quantity_percent: float = 0.0
+
+    def clamp(self) -> "RefillConfig":
+        return RefillConfig(
+            enabled_after_tp1=bool(self.enabled_after_tp1),
+            price_offset_percent=float(self.price_offset_percent),
+            quantity_percent=float(self.quantity_percent),
+        )
+
+
+@dataclass(slots=True)
+class InstrumentSettings:
+    """Полный набор пользовательских настроек для инструмента."""
+
+    symbol: str
+    base_quantity: float
+    entry_trigger_price: float
+    entry_trigger_direction: int = 2
+    trigger_by: str = "LastPrice"
+    take_profits: List[TakeProfitLevel] = field(default_factory=list)
+    stop_losses: List[StopLossLevel] = field(default_factory=list)
+    refill: RefillConfig = field(default_factory=RefillConfig)
+
+    def clamp(self) -> "InstrumentSettings":
+        return InstrumentSettings(
+            symbol=self.symbol.strip().upper(),
+            base_quantity=float(self.base_quantity),
+            entry_trigger_price=float(self.entry_trigger_price),
+            entry_trigger_direction=int(self.entry_trigger_direction),
+            trigger_by=self.trigger_by,
+            take_profits=[tp.clamp() for tp in self.take_profits],
+            stop_losses=[sl.clamp() for sl in self.stop_losses],
+            refill=self.refill.clamp(),
+        )
+
+    def validate(self) -> None:
+        if not self.symbol:
+            raise ValueError("Символ не может быть пустым")
+        if self.base_quantity <= 0:
+            raise ValueError("Базовый объём должен быть больше нуля")
+        if self.entry_trigger_price <= 0:
+            raise ValueError("Цена входа должна быть больше нуля")
+        if self.entry_trigger_direction not in {1, 2}:
+            raise ValueError("Направление триггера может быть только 1 или 2")
+        if len(self.take_profits) != 2:
+            raise ValueError("Должно быть настроено два тейк-профита")
+        if any(tp.offset_percent <= 0 for tp in self.take_profits):
+            raise ValueError("Процент смещения TP должен быть положительным")
+        if abs(sum(tp.quantity_percent for tp in self.take_profits) - 100.0) > 1e-6:
+            raise ValueError("Сумма процентов объёма для TP должна быть равна 100")
+        if not self.stop_losses:
+            raise ValueError("Нужно настроить хотя бы один стоп-лосс")
+        if len(self.stop_losses) > 10:
+            raise ValueError("Количество стоп-лоссов не может превышать 10")
+        if any(sl.offset_percent <= 0 for sl in self.stop_losses):
+            raise ValueError("Процент смещения SL должен быть положительным")
+        if any(sl.quantity_percent <= 0 for sl in self.stop_losses):
+            raise ValueError("Процент объёма SL должен быть положительным")
+
+    @property
+    def stop_losses_sorted(self) -> List[StopLossLevel]:
+        return sorted(self.stop_losses, key=lambda sl: sl.offset_percent)
+
+    def clone(self) -> "InstrumentSettings":
+        return InstrumentSettings(
+            symbol=self.symbol,
+            base_quantity=self.base_quantity,
+            entry_trigger_price=self.entry_trigger_price,
+            entry_trigger_direction=self.entry_trigger_direction,
+            trigger_by=self.trigger_by,
+            take_profits=[tp.clamp() for tp in self.take_profits],
+            stop_losses=[sl.clamp() for sl in self.stop_losses],
+            refill=self.refill.clamp(),
+        )

--- a/src/hedgebot/engine.py
+++ b/src/hedgebot/engine.py
@@ -1,0 +1,460 @@
+from __future__ import annotations
+
+import asyncio
+from contextlib import suppress
+from datetime import datetime
+from decimal import Decimal, ROUND_DOWN, ROUND_HALF_UP
+from typing import Dict, Optional
+
+from .bybit_client import BybitClient, SymbolFilters
+from .config import InstrumentSettings
+from .events import LogEvent, OrdersEvent, StatusEvent
+from .state import InstrumentStatus, ManagedOrder, OrderKind
+from .utils import clamp_to_step_str, ensure_minimum
+
+
+class InstrumentEngine:
+    """Управляет логикой торговли по одному инструменту."""
+
+    def __init__(self, settings: InstrumentSettings, client: BybitClient) -> None:
+        self.settings = settings.clone()
+        self.client = client
+        self.status: InstrumentStatus = InstrumentStatus.CONFIGURED
+        self.events: asyncio.Queue = asyncio.Queue()
+
+        self._orders: Dict[str, ManagedOrder] = {}
+        self._symbol_filters: Optional[SymbolFilters] = None
+        self._poll_task: Optional[asyncio.Task] = None
+        self._stop_event = asyncio.Event()
+        self._protection_deployed = False
+        self._entry_prices: Dict[str, float] = {"long": 0.0, "short": 0.0}
+        self._base_qty_side: Dict[str, float] = {"long": self.settings.base_quantity, "short": self.settings.base_quantity}
+        self._finalized = False
+
+    # ------------------------------------------------------------------
+    # Публичный API
+    # ------------------------------------------------------------------
+    async def update_settings(self, settings: InstrumentSettings) -> None:
+        if self.status in {InstrumentStatus.WAITING_ENTRY, InstrumentStatus.ACTIVE}:
+            raise RuntimeError("Нельзя менять настройки во время работы")
+        self.settings = settings.clone()
+        self.settings.validate()
+        await self._emit_status(InstrumentStatus.CONFIGURED, "Настройки обновлены")
+
+    async def start(self) -> None:
+        if self.status in {InstrumentStatus.WAITING_ENTRY, InstrumentStatus.ACTIVE}:
+            raise RuntimeError("Инструмент уже запущен")
+        self.settings.validate()
+        ok, reason = await self.client.ensure_symbol_trading(self.settings.symbol)
+        if not ok:
+            raise RuntimeError(f"Символ {self.settings.symbol} недоступен для торговли ({reason})")
+        await self.client.ensure_hedge_mode(self.settings.symbol)
+        self._symbol_filters = await self.client.get_symbol_filters(self.settings.symbol)
+
+        self._orders.clear()
+        self._protection_deployed = False
+        self._stop_event = asyncio.Event()
+        self._finalized = False
+
+        await self._emit_status(InstrumentStatus.WAITING_ENTRY, "Выставление условных ордеров входа")
+        await self._place_entry_orders()
+        await self._emit_orders_event()
+
+        if self._poll_task and not self._poll_task.done():
+            self._poll_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await self._poll_task
+        self._poll_task = asyncio.create_task(self._poll_loop())
+
+    async def stop(self) -> None:
+        self._stop_event.set()
+        if self._poll_task:
+            self._poll_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await self._poll_task
+            self._poll_task = None
+        await self.client.cancel_all_orders(self.settings.symbol)
+        await self._emit_orders_event()
+        await self._emit_status(InstrumentStatus.STOPPED, "Остановлено пользователем")
+
+    async def close_all(self) -> None:
+        self._stop_event.set()
+        if self._poll_task:
+            self._poll_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await self._poll_task
+            self._poll_task = None
+        await self.client.cancel_all_orders(self.settings.symbol)
+        await self.client.close_position_market(self.settings.symbol, "long")
+        await self.client.close_position_market(self.settings.symbol, "short")
+        await self._emit_orders_event()
+        await self._emit_status(InstrumentStatus.COMPLETED, "Позиция закрыта вручную")
+
+    # ------------------------------------------------------------------
+    # Основной цикл мониторинга
+    # ------------------------------------------------------------------
+    async def _poll_loop(self) -> None:
+        try:
+            while not self._stop_event.is_set():
+                await self._poll_once()
+                await asyncio.sleep(3)
+        except asyncio.CancelledError:
+            pass
+        except Exception as exc:  # pylint: disable=broad-except
+            await self._handle_error(exc)
+
+    async def _poll_once(self) -> None:
+        symbol = self.settings.symbol
+        open_orders = await self.client.get_open_orders(symbol)
+        open_map = {o.get("orderId"): o for o in open_orders if o.get("orderId")}
+
+        for order in list(self._orders.values()):
+            prev_status = order.status
+            data = open_map.get(order.order_id)
+            status = prev_status
+            if data:
+                status = self._extract_status(data) or prev_status
+            else:
+                data = await self.client.get_order_info(symbol, order.order_id)
+                if data:
+                    status = self._extract_status(data) or prev_status
+            if status != prev_status:
+                order.mark_status(status)
+                self._update_order_from_data(order, data)
+                await self._handle_order_status_change(order, status, data)
+
+        await self._emit_orders_event()
+
+    # ------------------------------------------------------------------
+    # Размещение ордеров
+    # ------------------------------------------------------------------
+    async def _place_entry_orders(self) -> None:
+        filters = self._require_filters()
+        qty_str = self._format_qty(self.settings.base_quantity, filters)
+        trigger_price = self._format_price(self.settings.entry_trigger_price, filters)
+
+        order_long_id = await self.client.place_conditional_market_order(
+            symbol=self.settings.symbol,
+            side="Buy",
+            qty=qty_str,
+            trigger_price=trigger_price,
+            trigger_direction=self.settings.entry_trigger_direction,
+            trigger_by=self.settings.trigger_by,
+            position_idx=1,
+            reduce_only=False,
+            close_on_trigger=False,
+        )
+        self._orders[order_long_id] = ManagedOrder(
+            order_id=order_long_id,
+            symbol=self.settings.symbol,
+            side="Buy",
+            position_side="long",
+            kind=OrderKind.ENTRY,
+            quantity=float(Decimal(qty_str)),
+            trigger_price=float(trigger_price),
+            reduce_only=False,
+        )
+        await self._log(f"Условный ордер на вход LONG выставлен ({order_long_id})")
+
+        order_short_id = await self.client.place_conditional_market_order(
+            symbol=self.settings.symbol,
+            side="Sell",
+            qty=qty_str,
+            trigger_price=trigger_price,
+            trigger_direction=3 - self.settings.entry_trigger_direction,
+            trigger_by=self.settings.trigger_by,
+            position_idx=2,
+            reduce_only=False,
+            close_on_trigger=False,
+        )
+        self._orders[order_short_id] = ManagedOrder(
+            order_id=order_short_id,
+            symbol=self.settings.symbol,
+            side="Sell",
+            position_side="short",
+            kind=OrderKind.ENTRY,
+            quantity=float(Decimal(qty_str)),
+            trigger_price=float(trigger_price),
+            reduce_only=False,
+        )
+        await self._log(f"Условный ордер на вход SHORT выставлен ({order_short_id})")
+
+    async def _deploy_protection_orders(self) -> None:
+        if self._protection_deployed:
+            return
+        filters = self._require_filters()
+
+        for side in ("long", "short"):
+            entry_price = self._entry_prices.get(side)
+            if not entry_price:
+                position = await self.client.get_position_side(self.settings.symbol, side)
+                if position:
+                    entry_price = float(position.get("avgPrice") or position.get("entryPrice") or 0)
+                    self._entry_prices[side] = entry_price
+            if not entry_price or entry_price <= 0:
+                raise RuntimeError(f"Не удалось определить цену входа для {side}")
+
+            base_qty = self._base_qty_side.get(side, self.settings.base_quantity)
+            await self._create_take_profits(side, entry_price, base_qty, filters)
+            await self._create_stop_losses(side, entry_price, base_qty, filters)
+
+        self._protection_deployed = True
+        await self._emit_status(InstrumentStatus.ACTIVE, "Позиции открыты, ордера защиты выставлены")
+
+    async def _create_take_profits(
+        self,
+        side: str,
+        entry_price: float,
+        base_qty: float,
+        filters: SymbolFilters,
+    ) -> None:
+        for idx, tp in enumerate(self.settings.take_profits, start=1):
+            qty = base_qty * tp.quantity_percent / 100.0
+            qty_str = self._format_qty(qty, filters)
+            if side == "long":
+                price = entry_price * (1 + tp.offset_percent / 100.0)
+                order_side = "Sell"
+                position_idx = 1
+            else:
+                price = entry_price * (1 - tp.offset_percent / 100.0)
+                order_side = "Buy"
+                position_idx = 2
+            price_str = self._format_price(price, filters)
+            order_id = await self.client.place_limit_order(
+                symbol=self.settings.symbol,
+                side=order_side,
+                qty=qty_str,
+                price=price_str,
+                position_idx=position_idx,
+                reduce_only=True,
+            )
+            kind = OrderKind.FINAL_TAKE_PROFIT if idx == len(self.settings.take_profits) else OrderKind.TAKE_PROFIT
+            self._orders[order_id] = ManagedOrder(
+                order_id=order_id,
+                symbol=self.settings.symbol,
+                side=order_side,
+                position_side=side,
+                kind=kind,
+                quantity=float(Decimal(qty_str)),
+                price=float(price_str),
+                level=idx,
+                reduce_only=True,
+            )
+            await self._log(f"TP{idx} для {side.upper()} выставлен по цене {price_str} ({order_id})")
+
+    async def _create_stop_losses(
+        self,
+        side: str,
+        entry_price: float,
+        base_qty: float,
+        filters: SymbolFilters,
+    ) -> None:
+        sorted_stops = self.settings.stop_losses_sorted
+        for idx, sl in enumerate(sorted_stops, start=1):
+            qty = base_qty * sl.quantity_percent / 100.0
+            qty_str = self._format_qty(qty, filters)
+            if side == "long":
+                trigger_price = entry_price * (1 - sl.offset_percent / 100.0)
+                order_side = "Sell"
+                position_idx = 1
+                trigger_direction = 2
+            else:
+                trigger_price = entry_price * (1 + sl.offset_percent / 100.0)
+                order_side = "Buy"
+                position_idx = 2
+                trigger_direction = 1
+            trigger_price_str = self._format_price(trigger_price, filters)
+            order_id = await self.client.place_conditional_market_order(
+                symbol=self.settings.symbol,
+                side=order_side,
+                qty=qty_str,
+                trigger_price=trigger_price_str,
+                trigger_direction=trigger_direction,
+                trigger_by=self.settings.trigger_by,
+                position_idx=position_idx,
+                reduce_only=True,
+                close_on_trigger=True,
+            )
+            self._orders[order_id] = ManagedOrder(
+                order_id=order_id,
+                symbol=self.settings.symbol,
+                side=order_side,
+                position_side=side,
+                kind=OrderKind.STOP_LOSS,
+                quantity=float(Decimal(qty_str)),
+                trigger_price=float(trigger_price_str),
+                level=idx,
+                reduce_only=True,
+            )
+            await self._log(f"SL{idx} для {side.upper()} выставлен по цене {trigger_price_str} ({order_id})")
+
+    # ------------------------------------------------------------------
+    # Обработка статусов
+    # ------------------------------------------------------------------
+    async def _handle_order_status_change(self, order: ManagedOrder, status: str, data: Optional[dict]) -> None:
+        if status == "Filled":
+            await self._on_order_filled(order, data)
+        elif status in {"Cancelled", "Rejected"}:
+            await self._log(f"Ордер {order.order_id} отменён ({order.kind.value})", level="warning")
+        elif status == "New":
+            await self._log(f"Ордер {order.order_id} принят биржей", level="debug")
+
+    async def _on_order_filled(self, order: ManagedOrder, data: Optional[dict]) -> None:
+        qty = float(data.get("cumExecQty") or data.get("qty") or order.quantity) if data else order.quantity
+        price = float(data.get("avgPrice") or data.get("triggerPrice") or data.get("price") or order.price or 0) if data else order.price or 0
+        await self._log(f"Ордер {order.order_id} ({order.kind.value}) исполнен на {qty}")
+
+        if order.kind == OrderKind.ENTRY:
+            self._entry_prices[order.position_side] = price or self.settings.entry_trigger_price
+            self._base_qty_side[order.position_side] = qty
+            await self._check_activation_ready()
+        elif order.kind == OrderKind.TAKE_PROFIT:
+            await self._maybe_place_refill_after_tp(order.position_side, qty)
+        elif order.kind == OrderKind.FINAL_TAKE_PROFIT:
+            await self._finalize_trade(f"Финальный TP достигнут для {order.position_side.upper()}")
+        elif order.kind == OrderKind.STOP_LOSS:
+            await self._place_refill_after_stop(order.position_side, qty)
+        elif order.kind == OrderKind.REFILL:
+            await self._log(f"Доливка {order.position_side.upper()} выполнена на {qty}")
+
+    async def _check_activation_ready(self) -> None:
+        if all(self._entry_prices.get(side) for side in ("long", "short")) and not self._protection_deployed:
+            await self._deploy_protection_orders()
+
+    async def _maybe_place_refill_after_tp(self, side: str, qty: float) -> None:
+        refill = self.settings.refill
+        if not refill.enabled_after_tp1 or refill.quantity_percent <= 0:
+            return
+        base_qty = self._base_qty_side.get(side, self.settings.base_quantity)
+        refill_qty = base_qty * refill.quantity_percent / 100.0
+        refill_qty = min(refill_qty, qty)
+        if refill_qty <= 0:
+            return
+        filters = self._require_filters()
+        qty_str = self._format_qty(refill_qty, filters)
+        entry_price = self._entry_prices.get(side) or self.settings.entry_trigger_price
+        if side == "long":
+            price = entry_price * (1 - refill.price_offset_percent / 100.0)
+            order_side = "Buy"
+            position_idx = 1
+        else:
+            price = entry_price * (1 + refill.price_offset_percent / 100.0)
+            order_side = "Sell"
+            position_idx = 2
+        price_str = self._format_price(price, filters)
+        order_id = await self.client.place_limit_order(
+            symbol=self.settings.symbol,
+            side=order_side,
+            qty=qty_str,
+            price=price_str,
+            position_idx=position_idx,
+            reduce_only=False,
+        )
+        self._orders[order_id] = ManagedOrder(
+            order_id=order_id,
+            symbol=self.settings.symbol,
+            side=order_side,
+            position_side=side,
+            kind=OrderKind.REFILL,
+            quantity=float(Decimal(qty_str)),
+            price=float(price_str),
+            reduce_only=False,
+        )
+        await self._log(f"После TP выставлена доливка {side.upper()} по цене {price_str} ({order_id})")
+
+    async def _place_refill_after_stop(self, side: str, qty: float) -> None:
+        if qty <= 0:
+            return
+        filters = self._require_filters()
+        qty_str = self._format_qty(qty, filters)
+        entry_price = self._entry_prices.get(side) or self.settings.entry_trigger_price
+        price_str = self._format_price(entry_price, filters)
+        if side == "long":
+            order_side = "Buy"
+            position_idx = 1
+        else:
+            order_side = "Sell"
+            position_idx = 2
+        order_id = await self.client.place_limit_order(
+            symbol=self.settings.symbol,
+            side=order_side,
+            qty=qty_str,
+            price=price_str,
+            position_idx=position_idx,
+            reduce_only=False,
+        )
+        self._orders[order_id] = ManagedOrder(
+            order_id=order_id,
+            symbol=self.settings.symbol,
+            side=order_side,
+            position_side=side,
+            kind=OrderKind.REFILL,
+            quantity=float(Decimal(qty_str)),
+            price=float(price_str),
+            reduce_only=False,
+        )
+        await self._log(f"После SL выставлена доливка {side.upper()} по цене {price_str} ({order_id})")
+
+    async def _finalize_trade(self, reason: str) -> None:
+        if self._finalized:
+            return
+        self._finalized = True
+        await self.client.cancel_all_orders(self.settings.symbol)
+        await self.client.close_position_market(self.settings.symbol, "long")
+        await self.client.close_position_market(self.settings.symbol, "short")
+        await self._emit_orders_event()
+        await self._emit_status(InstrumentStatus.COMPLETED, reason)
+        self._stop_event.set()
+        if self._poll_task:
+            self._poll_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await self._poll_task
+            self._poll_task = None
+
+    # ------------------------------------------------------------------
+    # Вспомогательные методы
+    # ------------------------------------------------------------------
+    def _require_filters(self) -> SymbolFilters:
+        if not self._symbol_filters:
+            raise RuntimeError("Не удалось получить биржевые фильтры")
+        return self._symbol_filters
+
+    def _format_qty(self, qty: float, filters: SymbolFilters) -> str:
+        qty = ensure_minimum(qty, filters.min_qty)
+        return clamp_to_step_str(qty, filters.qty_step, rounding=ROUND_DOWN)
+
+    def _format_price(self, price: float, filters: SymbolFilters) -> str:
+        return clamp_to_step_str(price, filters.tick_size, rounding=ROUND_HALF_UP)
+
+    def _extract_status(self, data: Optional[dict]) -> Optional[str]:
+        if not data:
+            return None
+        for key in ("orderStatus", "stopOrderStatus", "triggerStatus"):
+            status = data.get(key)
+            if status:
+                return status
+        return None
+
+    def _update_order_from_data(self, order: ManagedOrder, data: Optional[dict]) -> None:
+        if not data:
+            return
+        if data.get("price"):
+            order.price = float(data["price"])
+        if data.get("triggerPrice"):
+            order.trigger_price = float(data["triggerPrice"])
+
+    async def _emit_status(self, status: InstrumentStatus, details: Optional[str] = None) -> None:
+        self.status = status
+        await self.events.put(StatusEvent(self.settings.symbol, datetime.utcnow(), status, details))
+
+    async def _emit_orders_event(self) -> None:
+        await self.events.put(OrdersEvent(self.settings.symbol, datetime.utcnow(), list(self._orders.values())))
+
+    async def _log(self, message: str, level: str = "info") -> None:
+        await self.events.put(LogEvent(self.settings.symbol, datetime.utcnow(), level, message))
+
+    async def _handle_error(self, exc: Exception) -> None:
+        await self._log(f"Ошибка: {exc}", level="error")
+        await self._emit_status(InstrumentStatus.ERROR, str(exc))
+        self._stop_event.set()
+

--- a/src/hedgebot/events.py
+++ b/src/hedgebot/events.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import List
+
+from .state import InstrumentStatus, ManagedOrder
+
+
+@dataclass(slots=True)
+class InstrumentEvent:
+    symbol: str
+    timestamp: datetime
+
+
+@dataclass(slots=True)
+class StatusEvent(InstrumentEvent):
+    status: InstrumentStatus
+    details: str | None = None
+
+
+@dataclass(slots=True)
+class LogEvent(InstrumentEvent):
+    level: str
+    message: str
+
+
+@dataclass(slots=True)
+class OrdersEvent(InstrumentEvent):
+    orders: List[ManagedOrder]

--- a/src/hedgebot/state.py
+++ b/src/hedgebot/state.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from typing import Optional
+
+
+class InstrumentStatus(str, Enum):
+    CONFIGURED = "configured"
+    WAITING_ENTRY = "waiting_entry"
+    ACTIVE = "active"
+    STOPPED = "stopped"
+    COMPLETED = "completed"
+    ERROR = "error"
+
+
+class OrderKind(str, Enum):
+    ENTRY = "entry"
+    TAKE_PROFIT = "take_profit"
+    FINAL_TAKE_PROFIT = "final_take_profit"
+    STOP_LOSS = "stop_loss"
+    REFILL = "refill"
+
+
+@dataclass(slots=True)
+class ManagedOrder:
+    order_id: str
+    symbol: str
+    side: str
+    position_side: str
+    kind: OrderKind
+    quantity: float
+    price: Optional[float] = None
+    trigger_price: Optional[float] = None
+    level: Optional[int] = None
+    status: str = "New"
+    reduce_only: bool = True
+    created_at: datetime = field(default_factory=datetime.utcnow)
+    updated_at: datetime = field(default_factory=datetime.utcnow)
+
+    def as_dict(self) -> dict:
+        return {
+            "order_id": self.order_id,
+            "symbol": self.symbol,
+            "side": self.side,
+            "position_side": self.position_side,
+            "kind": self.kind.value,
+            "quantity": self.quantity,
+            "price": self.price,
+            "trigger_price": self.trigger_price,
+            "level": self.level,
+            "status": self.status,
+            "reduce_only": self.reduce_only,
+            "updated_at": self.updated_at.isoformat(timespec="seconds"),
+        }
+
+    def mark_status(self, status: str) -> None:
+        self.status = status
+        self.updated_at = datetime.utcnow()

--- a/src/hedgebot/ui/add_instrument.py
+++ b/src/hedgebot/ui/add_instrument.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+from typing import List
+
+from textual.app import ComposeResult
+from textual.containers import Grid, Horizontal, Vertical
+from textual.screen import ModalScreen
+from textual.widgets import Button, Checkbox, Input, Select, Static
+
+from ..config import InstrumentSettings, RefillConfig, StopLossLevel, TakeProfitLevel
+from .messages import AddInstrumentMessage
+
+
+class AddInstrumentScreen(ModalScreen[None]):
+    """Диалог добавления нового инструмента."""
+
+    def __init__(self, defaults: InstrumentSettings) -> None:
+        super().__init__()
+        self.defaults = defaults.clone()
+        self.message_label = Static("", classes="settings-message")
+
+        self.symbol_input = Input(value=self.defaults.symbol, placeholder="BTCUSDT")
+        self.quantity_input = Input(value=str(self.defaults.base_quantity), placeholder="Базовый объём")
+        self.trigger_price_input = Input(value=str(self.defaults.entry_trigger_price), placeholder="Цена триггера")
+        self.trigger_direction_select = Select(
+            options=[("Price >=", "1"), ("Price <=", "2")],
+            value=str(self.defaults.entry_trigger_direction),
+        )
+        self.trigger_by_select = Select(
+            options=[("Last", "LastPrice"), ("Mark", "MarkPrice"), ("Index", "IndexPrice")],
+            value=self.defaults.trigger_by,
+        )
+        self.tp1_offset_input = Input(value=str(self.defaults.take_profits[0].offset_percent))
+        self.tp1_qty_input = Input(value=str(self.defaults.take_profits[0].quantity_percent))
+        self.tp2_offset_input = Input(value=str(self.defaults.take_profits[1].offset_percent))
+        self.tp2_qty_input = Input(value=str(self.defaults.take_profits[1].quantity_percent))
+        stops_default = ",".join(f"{sl.offset_percent}:{sl.quantity_percent}" for sl in self.defaults.stop_losses)
+        self.stop_pairs_input = Input(value=stops_default, placeholder="0.5:30,1.0:30")
+        self.refill_checkbox = Checkbox(label="Доливка после TP1", value=self.defaults.refill.enabled_after_tp1)
+        self.refill_price_input = Input(value=str(self.defaults.refill.price_offset_percent))
+        self.refill_qty_input = Input(value=str(self.defaults.refill.quantity_percent))
+
+    def compose(self) -> ComposeResult:
+        with Vertical(classes="modal-body"):
+            yield Static("Добавление инструмента", classes="modal-title")
+            with Grid(classes="settings-grid"):
+                yield Static("Символ")
+                yield self.symbol_input
+                yield Static("Базовый объём")
+                yield self.quantity_input
+                yield Static("Цена входа")
+                yield self.trigger_price_input
+                yield Static("Направление триггера")
+                yield self.trigger_direction_select
+                yield Static("Триггер по")
+                yield self.trigger_by_select
+                yield Static("TP1 %")
+                yield self.tp1_offset_input
+                yield Static("TP1 объём %")
+                yield self.tp1_qty_input
+                yield Static("TP2 %")
+                yield self.tp2_offset_input
+                yield Static("TP2 объём %")
+                yield self.tp2_qty_input
+                yield Static("Стопы offset:qty")
+                yield self.stop_pairs_input
+                yield self.refill_checkbox
+                with Horizontal():
+                    yield Static("Цена доливки %")
+                    yield self.refill_price_input
+                    yield Static("Объём %")
+                    yield self.refill_qty_input
+            yield self.message_label
+            with Horizontal():
+                yield Button("Создать", id="create", variant="success")
+                yield Button("Отмена", id="cancel", variant="warning")
+
+    async def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "cancel":
+            self.dismiss(None)
+            return
+        if event.button.id == "create":
+            try:
+                settings = self._collect_settings()
+                await self.post_message(AddInstrumentMessage(settings))
+                self.message_label.set_classes("settings-message success")
+                self.message_label.update("Инструмент создан")
+                self.dismiss(None)
+            except Exception as exc:  # pylint: disable=broad-except
+                self.message_label.set_classes("settings-message error")
+                self.message_label.update(f"Ошибка: {exc}")
+
+    def _collect_settings(self) -> InstrumentSettings:
+        symbol = self.symbol_input.value.strip().upper()
+        base_qty = float(self.quantity_input.value)
+        trigger_price = float(self.trigger_price_input.value)
+        trigger_direction = int(self.trigger_direction_select.value or 2)
+        trigger_by = self.trigger_by_select.value or "LastPrice"
+        tp1 = TakeProfitLevel(offset_percent=float(self.tp1_offset_input.value), quantity_percent=float(self.tp1_qty_input.value))
+        tp2 = TakeProfitLevel(offset_percent=float(self.tp2_offset_input.value), quantity_percent=float(self.tp2_qty_input.value))
+        stops = self._parse_stop_levels(self.stop_pairs_input.value)
+        refill = RefillConfig(
+            enabled_after_tp1=self.refill_checkbox.value,
+            price_offset_percent=float(self.refill_price_input.value or 0),
+            quantity_percent=float(self.refill_qty_input.value or 0),
+        )
+        settings = InstrumentSettings(
+            symbol=symbol,
+            base_quantity=base_qty,
+            entry_trigger_price=trigger_price,
+            entry_trigger_direction=trigger_direction,
+            trigger_by=trigger_by,
+            take_profits=[tp1, tp2],
+            stop_losses=stops,
+            refill=refill,
+        )
+        settings.validate()
+        return settings
+
+    def _parse_stop_levels(self, value: str) -> List[StopLossLevel]:
+        parts = [p.strip() for p in (value or "").split(",") if p.strip()]
+        if not parts:
+            raise ValueError("Необходимо указать хотя бы один стоп-лосс")
+        levels: List[StopLossLevel] = []
+        for part in parts:
+            if ":" not in part:
+                raise ValueError("Неверный формат стопов. Используйте offset:qty")
+            offset_str, qty_str = part.split(":", 1)
+            levels.append(StopLossLevel(offset_percent=float(offset_str), quantity_percent=float(qty_str)))
+        return levels

--- a/src/hedgebot/ui/app.css
+++ b/src/hedgebot/ui/app.css
@@ -1,0 +1,57 @@
+#main-layout {
+    padding: 1 2;
+    gap: 1;
+}
+
+#control-bar {
+    gap: 1;
+}
+
+#instrument-scroll {
+    height: 1fr;
+    border: tall $surface;
+}
+
+.instrument-title {
+    text-style: bold;
+    margin: 1 0;
+}
+
+.settings-grid {
+    grid-size: 2;
+    grid-gutter: 1 0;
+    margin-bottom: 1;
+}
+
+.settings-message {
+    height: auto;
+}
+
+.settings-message.error {
+    color: $error;
+}
+
+.settings-message.success {
+    color: $success;
+}
+
+.status-label {
+    text-style: bold;
+}
+
+.status-pane {
+    gap: 1;
+}
+
+TextLog {
+    height: 20;
+}
+
+#instrument-container {
+    gap: 2;
+    padding: 1;
+}
+
+.client-status {
+    color: $success;
+}

--- a/src/hedgebot/ui/app.py
+++ b/src/hedgebot/ui/app.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import asyncio
+from contextlib import suppress
+from datetime import datetime
+import uuid
+from typing import Dict, Optional
+
+from textual.app import App, ComposeResult
+from textual.containers import Horizontal, Vertical, VerticalScroll
+from textual.widgets import Button, Footer, Header, Static
+
+from ..config import InstrumentSettings, RefillConfig, StopLossLevel, TakeProfitLevel
+from ..events import LogEvent, OrdersEvent, StatusEvent
+from ..state import InstrumentStatus
+from ..bybit_client import BybitClient
+from ..engine import InstrumentEngine
+from .add_instrument import AddInstrumentScreen
+from .instrument_widget import InstrumentWidget
+from .messages import (
+    AddInstrumentMessage,
+    InstrumentCommand,
+    InstrumentCommandMessage,
+    InstrumentEventMessage,
+)
+
+
+class HedgeBotApp(App):
+    CSS_PATH = "app.css"
+
+    BINDINGS = [
+        ("a", "open_add_dialog", "Добавить инструмент"),
+    ]
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.client: Optional[BybitClient] = None
+        self.engines: Dict[str, InstrumentEngine] = {}
+        self.widgets: Dict[str, InstrumentWidget] = {}
+        self.event_tasks: Dict[str, asyncio.Task] = {}
+        self.status_label: Static | None = None
+        self.instrument_container: Vertical | None = None
+        self._instrument_counter = 1
+
+    def compose(self) -> ComposeResult:
+        self.status_label = Static("", classes="client-status")
+        self.instrument_container = Vertical(id="instrument-container")
+
+        yield Header(show_clock=True)
+        with Vertical(id="main-layout"):
+            with Horizontal(id="control-bar"):
+                yield Button("Добавить инструмент", id="add", variant="primary")
+                yield Button("Запустить все", id="start-all", variant="success")
+                yield Button("Остановить все", id="stop-all", variant="warning")
+            yield self.status_label
+            yield VerticalScroll(self.instrument_container, id="instrument-scroll")
+        yield Footer()
+
+    async def on_mount(self) -> None:
+        try:
+            self.client = BybitClient()
+            self.status_label.update("API клиента инициализирован.")
+        except Exception as exc:  # pylint: disable=broad-except
+            self.status_label.update(f"Ошибка инициализации API: {exc}")
+
+    async def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "add":
+            await self.action_open_add_dialog()
+        elif event.button.id == "start-all":
+            await self._run_for_all("start")
+        elif event.button.id == "stop-all":
+            await self._run_for_all("stop")
+
+    async def action_open_add_dialog(self) -> None:
+        if not self.client:
+            self.status_label.update("API клиент недоступен. Проверьте настройки .env")
+            return
+        defaults = self._default_settings()
+        await self.push_screen(AddInstrumentScreen(defaults))
+
+    async def on_add_instrument_message(self, message: AddInstrumentMessage) -> None:
+        await self._create_instrument(message.settings)
+
+    async def on_instrument_command_message(self, message: InstrumentCommandMessage) -> None:
+        payload = message.payload
+        if payload.command == "remove":
+            await self._remove_instrument(payload.instrument_id)
+            return
+        await self._run_command(payload)
+
+    async def on_instrument_event_message(self, event: InstrumentEventMessage) -> None:
+        widget = self.widgets.get(event.instrument_id)
+        if widget:
+            await widget.post_message(event)
+
+    async def _create_instrument(self, settings: InstrumentSettings) -> None:
+        if not self.client:
+            self.status_label.update("API клиент недоступен")
+            return
+        instrument_id = f"{settings.symbol}-{self._instrument_counter}-{uuid.uuid4().hex[:4]}"
+        self._instrument_counter += 1
+        container = self.instrument_container
+        if not container:
+            return
+        engine = InstrumentEngine(settings, self.client)
+        widget = InstrumentWidget(instrument_id, settings)
+        self.engines[instrument_id] = engine
+        self.widgets[instrument_id] = widget
+        await container.mount(widget)
+        task = self.add_background_task(self._consume_events(instrument_id, engine))
+        self.event_tasks[instrument_id] = task
+        await engine.events.put(StatusEvent(settings.symbol, datetime.utcnow(), InstrumentStatus.CONFIGURED, "Инструмент создан"))
+        await engine.events.put(OrdersEvent(settings.symbol, datetime.utcnow(), []))
+        await engine.events.put(LogEvent(settings.symbol, datetime.utcnow(), "info", "Инструмент добавлен"))
+
+    async def _consume_events(self, instrument_id: str, engine: InstrumentEngine) -> None:
+        while True:
+            event = await engine.events.get()
+            await self.post_message(InstrumentEventMessage(instrument_id, event))
+
+    async def _run_command(self, payload: InstrumentCommand) -> None:
+        engine = self.engines.get(payload.instrument_id)
+        if not engine:
+            return
+        try:
+            if payload.command == "start":
+                await engine.start()
+            elif payload.command == "stop":
+                await engine.stop()
+            elif payload.command == "close":
+                await engine.close_all()
+            elif payload.command == "update" and payload.settings:
+                await engine.update_settings(payload.settings)
+        except Exception as exc:  # pylint: disable=broad-except
+            await engine.events.put(LogEvent(engine.settings.symbol, datetime.utcnow(), "error", f"Ошибка команды: {exc}"))
+
+    async def _remove_instrument(self, instrument_id: str) -> None:
+        engine = self.engines.pop(instrument_id, None)
+        widget = self.widgets.pop(instrument_id, None)
+        task = self.event_tasks.pop(instrument_id, None)
+        if task:
+            task.cancel()
+            with suppress(asyncio.CancelledError):
+                await task
+        if engine:
+            try:
+                await engine.stop()
+            except Exception:  # pylint: disable=broad-except
+                pass
+        if widget:
+            widget.remove()
+
+    async def _run_for_all(self, command: str) -> None:
+        tasks = []
+        for iid in list(self.engines.keys()):
+            payload = InstrumentCommand(iid, command)
+            tasks.append(self._run_command(payload))
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+
+    def _default_settings(self) -> InstrumentSettings:
+        return InstrumentSettings(
+            symbol="BTCUSDT",
+            base_quantity=0.001,
+            entry_trigger_price=25000.0,
+            entry_trigger_direction=2,
+            trigger_by="LastPrice",
+            take_profits=[
+                TakeProfitLevel(offset_percent=0.5, quantity_percent=50.0),
+                TakeProfitLevel(offset_percent=1.0, quantity_percent=50.0),
+            ],
+            stop_losses=[
+                StopLossLevel(offset_percent=0.5, quantity_percent=50.0),
+                StopLossLevel(offset_percent=1.0, quantity_percent=50.0),
+            ],
+            refill=RefillConfig(enabled_after_tp1=False, price_offset_percent=0.2, quantity_percent=25.0),
+        )
+
+
+def run_app() -> None:
+    app = HedgeBotApp()
+    app.run()

--- a/src/hedgebot/ui/instrument_widget.py
+++ b/src/hedgebot/ui/instrument_widget.py
@@ -1,0 +1,255 @@
+from __future__ import annotations
+
+from typing import List
+
+from textual.app import ComposeResult
+from textual.containers import Grid, Horizontal, Vertical
+from textual.widgets import (
+    Button,
+    Checkbox,
+    DataTable,
+    Input,
+    Select,
+    Static,
+    TabPane,
+    TabbedContent,
+    TextLog,
+)
+
+from ..config import InstrumentSettings, RefillConfig, StopLossLevel, TakeProfitLevel
+from ..events import LogEvent, OrdersEvent, StatusEvent
+from ..state import InstrumentStatus, ManagedOrder
+from .messages import InstrumentCommand, InstrumentCommandMessage, InstrumentEventMessage
+
+
+class InstrumentWidget(Vertical):
+    """Виджет с вкладками для одного инструмента."""
+
+    def __init__(self, instrument_id: str, settings: InstrumentSettings) -> None:
+        super().__init__(id=f"instrument-{instrument_id}")
+        self.instrument_id = instrument_id
+        self.settings = settings.clone()
+
+        # Настройки формы
+        self.symbol_input = Input(value=self.settings.symbol, placeholder="BTCUSDT", id=f"{instrument_id}-symbol")
+        self.quantity_input = Input(value=str(self.settings.base_quantity), placeholder="Базовый объём", id=f"{instrument_id}-qty")
+        self.trigger_price_input = Input(value=str(self.settings.entry_trigger_price), placeholder="Цена триггера", id=f"{instrument_id}-trigger-price")
+        self.trigger_direction_select = Select(
+            options=[("Price >=", "1"), ("Price <=", "2")],
+            value=str(self.settings.entry_trigger_direction),
+            id=f"{instrument_id}-direction",
+        )
+        self.trigger_by_select = Select(
+            options=[("Last", "LastPrice"), ("Mark", "MarkPrice"), ("Index", "IndexPrice")],
+            value=self.settings.trigger_by,
+            id=f"{instrument_id}-trigger-by",
+        )
+        self.tp1_offset_input = Input(value=str(self.settings.take_profits[0].offset_percent), placeholder="TP1 %", id=f"{instrument_id}-tp1-offset")
+        self.tp1_qty_input = Input(value=str(self.settings.take_profits[0].quantity_percent), placeholder="TP1 объём %", id=f"{instrument_id}-tp1-qty")
+        self.tp2_offset_input = Input(value=str(self.settings.take_profits[1].offset_percent), placeholder="TP2 %", id=f"{instrument_id}-tp2-offset")
+        self.tp2_qty_input = Input(value=str(self.settings.take_profits[1].quantity_percent), placeholder="TP2 объём %", id=f"{instrument_id}-tp2-qty")
+        stops_default = ",".join(f"{sl.offset_percent}:{sl.quantity_percent}" for sl in self.settings.stop_losses)
+        self.stop_pairs_input = Input(value=stops_default, placeholder="0.5:30,1.0:30,1.5:40", id=f"{instrument_id}-stops")
+        self.refill_checkbox = Checkbox(label="Доливка после TP1", value=self.settings.refill.enabled_after_tp1, id=f"{instrument_id}-refill-enabled")
+        self.refill_price_input = Input(value=str(self.settings.refill.price_offset_percent), placeholder="Смещение цены %", id=f"{instrument_id}-refill-price")
+        self.refill_qty_input = Input(value=str(self.settings.refill.quantity_percent), placeholder="Объём %", id=f"{instrument_id}-refill-qty")
+        self.settings_message = Static("", classes="settings-message")
+        self.title_label = Static(f"Инструмент {self.settings.symbol}", classes="instrument-title")
+
+        # Статус и управление
+        self.status_label = Static("Статус: CONFIGURED", classes="status-label")
+        self.status_details = Static("", classes="status-details")
+        self.start_button = Button("Старт", id=f"{instrument_id}-start", variant="success")
+        self.stop_button = Button("Стоп", id=f"{instrument_id}-stop", variant="warning")
+        self.close_button = Button("Закрыть всё", id=f"{instrument_id}-close", variant="error")
+        self.remove_button = Button("Удалить", id=f"{instrument_id}-remove", variant="primary")
+
+        # Ордеры и лог
+        self.orders_table = DataTable(id=f"{instrument_id}-orders")
+        self.orders_table.add_columns(
+            "ID", "Тип", "Сторона", "Позиция", "Кол-во", "Цена", "Триггер", "RO", "Статус", "Обновлено"
+        )
+        self.log_view = TextLog(id=f"{instrument_id}-log", highlight=True, wrap=False)
+        self.log_view.max_lines = 500
+        self._update_button_states(InstrumentStatus.CONFIGURED)
+
+    def compose(self) -> ComposeResult:
+        yield self.title_label
+        with TabbedContent(id=f"tabs-{self.instrument_id}"):
+            with TabPane("Настройки", id=f"{self.instrument_id}-settings-tab"):
+                yield self._compose_settings_tab()
+            with TabPane("Статус", id=f"{self.instrument_id}-status-tab"):
+                yield self._compose_status_tab()
+            with TabPane("Ордеры", id=f"{self.instrument_id}-orders-tab"):
+                yield self._compose_orders_tab()
+            with TabPane("Лог", id=f"{self.instrument_id}-log-tab"):
+                yield self._compose_log_tab()
+
+    # ------------------------------------------------------------------
+    # Компоненты вкладок
+    # ------------------------------------------------------------------
+    def _compose_settings_tab(self) -> ComposeResult:
+        with Grid(classes="settings-grid"):
+            yield Static("Символ")
+            yield self.symbol_input
+            yield Static("Базовый объём")
+            yield self.quantity_input
+            yield Static("Цена входа")
+            yield self.trigger_price_input
+            yield Static("Направление триггера")
+            yield self.trigger_direction_select
+            yield Static("Триггер по")
+            yield self.trigger_by_select
+            yield Static("TP1 %")
+            yield self.tp1_offset_input
+            yield Static("TP1 объём %")
+            yield self.tp1_qty_input
+            yield Static("TP2 %")
+            yield self.tp2_offset_input
+            yield Static("TP2 объём %")
+            yield self.tp2_qty_input
+            yield Static("Стопы offset:qty")
+            yield self.stop_pairs_input
+            yield self.refill_checkbox
+            with Horizontal():
+                yield Static("Цена доливки %")
+                yield self.refill_price_input
+                yield Static("Объём %")
+                yield self.refill_qty_input
+            yield self.settings_message
+            yield Button("Сохранить", id=f"{self.instrument_id}-save", variant="success")
+
+    def _compose_status_tab(self) -> ComposeResult:
+        with Vertical(classes="status-pane"):
+            yield self.status_label
+            yield self.status_details
+            with Horizontal():
+                yield self.start_button
+                yield self.stop_button
+                yield self.close_button
+                yield self.remove_button
+
+    def _compose_orders_tab(self) -> ComposeResult:
+        yield self.orders_table
+
+    def _compose_log_tab(self) -> ComposeResult:
+        yield self.log_view
+
+    # ------------------------------------------------------------------
+    # События
+    # ------------------------------------------------------------------
+    async def on_button_pressed(self, event: Button.Pressed) -> None:
+        button_id = event.button.id or ""
+        if button_id.endswith("-start"):
+            await self.post_message(InstrumentCommandMessage(InstrumentCommand(self.instrument_id, "start")))
+        elif button_id.endswith("-stop"):
+            await self.post_message(InstrumentCommandMessage(InstrumentCommand(self.instrument_id, "stop")))
+        elif button_id.endswith("-close"):
+            await self.post_message(InstrumentCommandMessage(InstrumentCommand(self.instrument_id, "close")))
+        elif button_id.endswith("-remove"):
+            await self.post_message(InstrumentCommandMessage(InstrumentCommand(self.instrument_id, "remove")))
+        elif button_id.endswith("-save"):
+            await self._submit_settings()
+
+    async def _submit_settings(self) -> None:
+        try:
+            settings = self._collect_settings_from_form()
+            await self.post_message(InstrumentCommandMessage(InstrumentCommand(self.instrument_id, "update", settings)))
+            self.settings = settings.clone()
+            self.title_label.update(f"Инструмент {self.settings.symbol}")
+            self.settings_message.set_classes("settings-message success")
+            self.settings_message.update("Настройки сохранены")
+        except Exception as exc:  # pylint: disable=broad-except
+            self.settings_message.set_classes("settings-message error")
+            self.settings_message.update(f"Ошибка: {exc}")
+
+    def _collect_settings_from_form(self) -> InstrumentSettings:
+        symbol = self.symbol_input.value.strip().upper()
+        base_qty = float(self.quantity_input.value)
+        trigger_price = float(self.trigger_price_input.value)
+        trigger_direction = int(self.trigger_direction_select.value or 2)
+        trigger_by = self.trigger_by_select.value or "LastPrice"
+        tp1 = TakeProfitLevel(offset_percent=float(self.tp1_offset_input.value), quantity_percent=float(self.tp1_qty_input.value))
+        tp2 = TakeProfitLevel(offset_percent=float(self.tp2_offset_input.value), quantity_percent=float(self.tp2_qty_input.value))
+        stops = self._parse_stop_levels(self.stop_pairs_input.value)
+        refill_enabled = self.refill_checkbox.value
+        refill_price = float(self.refill_price_input.value or 0)
+        refill_qty = float(self.refill_qty_input.value or 0)
+        settings = InstrumentSettings(
+            symbol=symbol,
+            base_quantity=base_qty,
+            entry_trigger_price=trigger_price,
+            entry_trigger_direction=trigger_direction,
+            trigger_by=trigger_by,
+            take_profits=[tp1, tp2],
+            stop_losses=stops,
+            refill=RefillConfig(
+                enabled_after_tp1=refill_enabled,
+                price_offset_percent=refill_price,
+                quantity_percent=refill_qty,
+            ),
+        )
+        settings.validate()
+        return settings
+
+    def _parse_stop_levels(self, value: str) -> List[StopLossLevel]:
+        parts = [p.strip() for p in (value or "").split(",") if p.strip()]
+        levels: List[StopLossLevel] = []
+        for part in parts:
+            if ":" not in part:
+                raise ValueError("Неверный формат стопов. Используйте offset:qty через запятую")
+            offset_str, qty_str = part.split(":", 1)
+            levels.append(StopLossLevel(offset_percent=float(offset_str), quantity_percent=float(qty_str)))
+        return levels
+
+    async def on_instrument_event_message(self, event: InstrumentEventMessage) -> None:
+        if event.instrument_id != self.instrument_id:
+            return
+        payload = event.event
+        if isinstance(payload, StatusEvent):
+            await self._handle_status_event(payload)
+        elif isinstance(payload, LogEvent):
+            self._handle_log_event(payload)
+        elif isinstance(payload, OrdersEvent):
+            self._handle_orders_event(payload)
+
+    async def _handle_status_event(self, event: StatusEvent) -> None:
+        self.status_label.update(f"Статус: {event.status.value.upper()}")
+        details = event.details or ""
+        self.status_details.update(details)
+        self._update_button_states(event.status)
+
+    def _handle_log_event(self, event: LogEvent) -> None:
+        timestamp = event.timestamp.strftime("%H:%M:%S")
+        style = {
+            "info": "green",
+            "warning": "yellow",
+            "error": "red",
+            "debug": "dim",
+        }.get(event.level, "white")
+        self.log_view.write(f"[{timestamp}] {event.message}", style=style)
+
+    def _handle_orders_event(self, event: OrdersEvent) -> None:
+        self.orders_table.clear(rows=True)
+        for order in event.orders:
+            self.orders_table.add_row(*self._order_to_row(order))
+
+    def _order_to_row(self, order: ManagedOrder) -> List[str]:
+        return [
+            order.order_id[-12:],
+            order.kind.value,
+            order.side,
+            order.position_side,
+            f"{order.quantity:.6f}",
+            f"{order.price:.4f}" if order.price else "-",
+            f"{order.trigger_price:.4f}" if order.trigger_price else "-",
+            "Y" if order.reduce_only else "N",
+            order.status,
+            order.updated_at.strftime("%H:%M:%S"),
+        ]
+
+    def _update_button_states(self, status: InstrumentStatus) -> None:
+        self.start_button.disabled = status in {InstrumentStatus.WAITING_ENTRY, InstrumentStatus.ACTIVE}
+        self.stop_button.disabled = status not in {InstrumentStatus.WAITING_ENTRY, InstrumentStatus.ACTIVE}
+        self.close_button.disabled = status == InstrumentStatus.CONFIGURED
+

--- a/src/hedgebot/ui/messages.py
+++ b/src/hedgebot/ui/messages.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal, Optional
+
+from textual.message import Message
+
+from ..config import InstrumentSettings
+from ..events import InstrumentEvent
+
+
+class InstrumentEventMessage(Message):
+    def __init__(self, instrument_id: str, event: InstrumentEvent) -> None:
+        super().__init__()
+        self.instrument_id = instrument_id
+        self.event = event
+
+
+@dataclass(slots=True)
+class InstrumentCommand:
+    instrument_id: str
+    command: Literal["start", "stop", "close", "update", "remove"]
+    settings: Optional[InstrumentSettings] = None
+
+
+class InstrumentCommandMessage(Message):
+    def __init__(self, payload: InstrumentCommand) -> None:
+        super().__init__()
+        self.payload = payload
+
+
+class AddInstrumentMessage(Message):
+    def __init__(self, settings: InstrumentSettings) -> None:
+        super().__init__()
+        self.settings = settings

--- a/src/hedgebot/utils.py
+++ b/src/hedgebot/utils.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from decimal import Decimal, ROUND_DOWN, ROUND_HALF_UP, getcontext
+
+getcontext().prec = 18
+
+
+def round_to_step(value: float, step: float, rounding=ROUND_DOWN) -> Decimal:
+    value_dec = Decimal(str(value))
+    step_dec = Decimal(str(step))
+    if step_dec == 0:
+        return value_dec
+    quant = (value_dec / step_dec).to_integral_value(rounding=rounding)
+    return quant * step_dec
+
+
+def format_decimal(value: Decimal | float) -> str:
+    dec = Decimal(value) if not isinstance(value, Decimal) else value
+    return format(dec.normalize(), 'f') if dec else "0"
+
+
+def clamp_to_step_str(value: float, step: float, rounding=ROUND_DOWN) -> str:
+    return format_decimal(round_to_step(value, step, rounding))
+
+
+def ensure_minimum(value: float, minimum: float) -> float:
+    return max(value, minimum)


### PR DESCRIPTION
## Summary
- build a Textual TUI application for managing hedge-mode instruments with configuration, status, orders and logging tabs
- implement a trading engine and Bybit REST client wrapper to deploy entry, take-profit, stop-loss, and refill orders per specification
- add configuration models, event messaging, and utility helpers to support the hedge-bot workflow

## Testing
- python -m compileall src main.py

------
https://chatgpt.com/codex/tasks/task_e_68d3e9886568832aa1f32595e733f06b